### PR TITLE
v3.9.0

### DIFF
--- a/VERSION.py
+++ b/VERSION.py
@@ -1,1 +1,1 @@
-bot_version = "v3.8.0"
+bot_version = "v3.9.0"

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -351,7 +351,7 @@ class AFK(commands.Cog):
         if revert_nick and state and state.origin_guild_id:
             guild = self.bot.get_guild(state.origin_guild_id)
             if guild:
-                member = guild.get_member(user_id)
+                member = guild.get_member(user_id) or await guild.fetch_member(user_id)
                 if member:
                     try:
                         await member.edit(nick=state.old_nick, reason="AFK ended")

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -66,9 +66,9 @@ class ViewMissedPings(PrivateView):
                 msg_link = f" [[Jump]](<https://discord.com/channels/{entry.guild_id}/{entry.channel_id}/{entry.message_id}>)"
 
             lines.append(
-                f'{idx}. {display_name} '
+                f'{idx}. {display_name} in **{guild.name}**'
                 f'(<t:{entry.timestamp}:d> <t:{entry.timestamp}:t>): '
-                f'"{entry.content}" {msg_link}'
+                f'"{entry.content}"{msg_link}\n\n'
             )
 
         paginator = ViewPaginator(
@@ -77,14 +77,21 @@ class ViewMissedPings(PrivateView):
             per_page=5,
             color=discord.Color(0x944ae8),
         )
+        try:
+            message = await interaction.user.send(
+                embed=paginator.format_embed(),
+                view=paginator
+            )
+            link = message.jump_url
+            sent = True
+        except discord.Forbidden:
+            await interaction.response.send_message("""I can't DM you the Missed Pings! Please first DM me "hi" so that Discord lets me DM you.""", ephemeral=True)
+            sent = False
 
-        await interaction.response.send_message(
-            embed=paginator.format_embed(),
-            view=paginator,
-            ephemeral=True,
-        )
+        if sent:
+            await interaction.response.send_message(f"I sent the Missed Pings to your DMs! [Click here to Jump]({link}).", ephemeral=True)
+            await self.cog.clear_missed_pings(self.user_id)
 
-        await self.cog.clear_missed_pings(self.user_id)
 
 
 class AFK(commands.Cog):
@@ -395,8 +402,13 @@ class AFK(commands.Cog):
             minutes = elapsed // 60
             base = f"Welcome back! You were AFK for **{minutes}** minutes!"
         else:
-            hours = elapsed // 3600
-            base = f"Welcome back! You were AFK for **{hours}** hours!"
+            hours, remainder = divmod(elapsed, 3600)
+            minutes = remainder // 60
+
+            if minutes > 0:
+                base = f"Welcome back! You were AFK for **{hours}** hours and **{minutes}** minutes!"
+            else:
+                base = f"Welcome back! You were AFK for **{hours}** hours!"
 
         if missed_count > 0 and state.save_missed_pings:
             base += f"\nYou have **{missed_count}** missed pings!"

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -223,7 +223,7 @@ class Alerts(commands.Cog):
             color=0xFFFFFF
         )
         embed.set_footer(text=f"You are #{position} to read this alert!")
-        embed.set_author(name="Alert from the Developer at Dopamine Studios")
+        embed.set_author(name="Alert from the Developer")
         embed.timestamp = datetime.fromtimestamp(alert.created_at)
         await interaction.response.send_message(embed=embed)
 

--- a/cogs/autoresponse.py
+++ b/cogs/autoresponse.py
@@ -357,6 +357,17 @@ class EditAutoresponsePage(PrivateLayoutView):
         container.add_item(row)
 
         row2 = discord.ui.ActionRow()
+        if self.record.response_type == "text":
+            response_btn_label = "Edit Response"
+        else:
+            response_btn_label = "Refresh Embed"
+
+        response_btn = discord.ui.Button(
+            label=response_btn_label,
+            style=discord.ButtonStyle.primary,
+        )
+
+        row2.add_item(response_btn)
         row2.add_item(delete_btn)
         container.add_item(row2)
 
@@ -418,6 +429,53 @@ class EditAutoresponsePage(PrivateLayoutView):
         delete_btn.callback = delete_callback
         return_btn.callback = return_dashboard_callback
 
+        async def response_action_callback(interaction: discord.Interaction):
+            if self.record.response_type == "text":
+                modal = EditTextResponseModal(self.cog, self.guild_id, self.record, parent_view=self)
+                await interaction.response.send_modal(modal)
+                return
+
+            embeds_cog = self.cog.bot.get_cog("Embeds")
+            if embeds_cog is None:
+                await interaction.response.send_message(
+                    "Embed system is not available right now. Please try again later.",
+                    ephemeral=True,
+                )
+                return
+
+            embeds = await embeds_cog.fetch_embeds_for_guild(interaction.guild.id)
+            if not embeds:
+                await interaction.response.send_message(
+                    "No saved embeds found for this server. Use `/embed` to create one first.",
+                    ephemeral=True,
+                )
+                return
+
+            async def on_pick(inter: discord.Interaction, content: Optional[str], embed_obj: discord.Embed):
+                await self.cog.update_autoresponse_embed(
+                    self.guild_id,
+                    self.record.id,
+                    content or None,
+                    embed_obj.to_dict(),
+                )
+                self.record.response_type = "embed"
+                self.record.embed_content = content or None
+                self.record.embed_data = embed_obj.to_dict()
+                self.build_layout()
+                await inter.response.edit_message(view=self)
+
+            view = UseEmbedPage(
+                user=self.user,
+                cog=embeds_cog,
+                guild_id=interaction.guild.id,
+                embeds=embeds,
+                returnembed=True,
+                on_pick=on_pick,
+            )
+            await interaction.response.edit_message(view=view)
+
+        response_btn.callback = response_action_callback
+
 
 class TriggerEditModal(discord.ui.Modal):
     def __init__(self, cog: "Autoresponse", guild_id: int, record: AutoresponseRecord, parent_view: EditAutoresponsePage):
@@ -447,6 +505,32 @@ class TriggerEditModal(discord.ui.Modal):
 
         await self.cog.update_autoresponse_trigger(self.guild_id, self.record.id, new_trigger)
         self.record.trigger = new_trigger
+        self.parent_view.build_layout()
+        await interaction.response.edit_message(view=self.parent_view)
+
+
+class EditTextResponseModal(discord.ui.Modal):
+    def __init__(self, cog: "Autoresponse", guild_id: int, record: AutoresponseRecord, parent_view: EditAutoresponsePage):
+        super().__init__(title="Edit Text Response")
+        self.cog = cog
+        self.guild_id = guild_id
+        self.record = record
+        self.parent_view = parent_view
+
+        self.content_input = discord.ui.TextInput(
+            label="Response Content",
+            style=discord.TextStyle.paragraph,
+            required=True,
+            max_length=2000,
+            default=record.response_text or "",
+        )
+        self.add_item(self.content_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        new_text = self.content_input.value
+        await self.cog.update_autoresponse_response_text(self.guild_id, self.record.id, new_text)
+        self.record.response_type = "text"
+        self.record.response_text = new_text
         self.parent_view.build_layout()
         await interaction.response.edit_message(view=self.parent_view)
 
@@ -1012,6 +1096,43 @@ class Autoresponse(commands.Cog):
             await db.commit()
         if guild_id in self.cache and ar_id in self.cache[guild_id]:
             self.cache[guild_id][ar_id].fuzzy_threshold = threshold
+
+    async def update_autoresponse_response_text(self, guild_id: int, ar_id: int, text: str):
+        async with self.acquire_db() as db:
+            await db.execute(
+                "UPDATE autoresponses SET response_type = ?, response_text = ?, embed_content = NULL, embed_data = NULL "
+                "WHERE id = ? AND guild_id = ?",
+                ("text", text, ar_id, guild_id),
+            )
+            await db.commit()
+        if guild_id in self.cache and ar_id in self.cache[guild_id]:
+            rec = self.cache[guild_id][ar_id]
+            rec.response_type = "text"
+            rec.response_text = text
+            rec.embed_content = None
+            rec.embed_data = None
+
+    async def update_autoresponse_embed(
+        self,
+        guild_id: int,
+        ar_id: int,
+        content: Optional[str],
+        embed_data: Dict[str, Any],
+    ):
+        raw_embed = _serialize_embed_data(embed_data)
+        async with self.acquire_db() as db:
+            await db.execute(
+                "UPDATE autoresponses SET response_type = ?, response_text = NULL, embed_content = ?, embed_data = ? "
+                "WHERE id = ? AND guild_id = ?",
+                ("embed", content, raw_embed, ar_id, guild_id),
+            )
+            await db.commit()
+        if guild_id in self.cache and ar_id in self.cache[guild_id]:
+            rec = self.cache[guild_id][ar_id]
+            rec.response_type = "embed"
+            rec.response_text = None
+            rec.embed_content = content
+            rec.embed_data = embed_data
 
     async def delete_autoresponse(self, guild_id: int, ar_id: int):
         async with self.acquire_db() as db:

--- a/cogs/autoresponse.py
+++ b/cogs/autoresponse.py
@@ -14,6 +14,7 @@ from rapidfuzz import fuzz
 from config import ARSPDB_PATH
 from dopamineframework import PrivateLayoutView, mod_check
 from cogs.embed import UseEmbedPage
+import re
 
 
 @dataclass
@@ -1048,7 +1049,9 @@ class Autoresponse(commands.Cog):
             if record.match_mode == "exact":
                 matched = msg_text == trigger
             elif record.match_mode == "partial":
-                matched = trigger in msg_text
+                pattern = rf"\b{re.escape(trigger)}\b"
+                flags = re.IGNORECASE
+                matched = bool(re.search(pattern, content, flags=flags))
             elif record.match_mode == "fuzzy":
                 if msg_text and trigger:
                     score = fuzz.ratio(trigger, msg_text)

--- a/cogs/autoresponse.py
+++ b/cogs/autoresponse.py
@@ -360,7 +360,7 @@ class EditAutoresponsePage(PrivateLayoutView):
         if self.record.response_type == "text":
             response_btn_label = "Edit Response"
         else:
-            response_btn_label = "Refresh Embed"
+            response_btn_label = "Edit Embed"
 
         response_btn = discord.ui.Button(
             label=response_btn_label,

--- a/cogs/discordphone.py
+++ b/cogs/discordphone.py
@@ -254,7 +254,7 @@ class DiscordPhone(commands.Cog):
             self.active_calls[chan_b.id] = call
             call.timeout_task = self.bot.loop.create_task(self.timeout_handler(call))
 
-            safe_msg = f"Connected! Say hi to the people on the other side!\nRemember, you can report problematic users: Click on three dots -> Apps -> Report DiscordPhone Message. Or, reply to the problematic message with `!!report <reason>`.\n-# Dopamine - a Dopamine Studios product. Providing the premium experience without the paywalls. [Click here](<https://discord.com/oauth2/authorize?client_id=1411266382380924938>) to invite."
+            safe_msg = f"Connected! Say hi to the people on the other side!\nRemember, you can report problematic users: Click on three dots -> Apps -> Report DiscordPhone Message. Or, reply to the problematic message with `!!report <reason>`.\n-# Dopamine - a Dopamine Studios product. Providing the premium experience without the paywalls. [Click here](<https://top.gg/bot/1411266382380924938/invite>) to invite."
 
             await chan_a.send(f"{partner_user.mention} {safe_msg}")
             await chan_b.send(f"{user.mention} {safe_msg}")

--- a/cogs/embed.py
+++ b/cogs/embed.py
@@ -778,7 +778,7 @@ class EmbedPreviewView(PrivateView):
             existing_id=self.existing_id,
         )
         self.existing_id = embed_id
-        await interaction.response.edit_message(content=f"Embed saved successfully with ID `{embed_id}`.", embed=None, view=None)
+        await interaction.response.edit_message(content=f"Embed saved successfully.", embed=None, view=None)
 
     @discord.ui.button(label="Save & Send", style=discord.ButtonStyle.blurple)
     async def save_and_send_button(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/cogs/embed.py
+++ b/cogs/embed.py
@@ -791,7 +791,7 @@ class EmbedPreviewView(PrivateView):
         self.existing_id = embed_id
 
         view = ViewChannelSelect(self.cog, self.draft)
-        await interaction.response.edit_message(content="Select the channel where you want the embed to be sent:", embed=None, view=view)
+        await interaction.response.edit_message(content="## Select the channel where you want the embed to be sent:", embed=None, view=view)
 
     @discord.ui.button(label="Edit", style=discord.ButtonStyle.primary)
     async def edit_button(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -13,6 +13,7 @@ from dopamineframework import PrivateLayoutView, PrivateView, mod_check
 
 from config import GDB_PATH
 from utils.time import get_duration_to_seconds, get_now_plus_seconds_unix
+from natsort import natsorted, ns
 
 ADJECTIVES = ["alpha", "beta", "delta", "sonic", "prime", "global", "pivot", "solid", "static", "linear", "vital", "core", "urban", "nomad"]
 NOUNS = ["node", "link", "point", "base", "grid", "zone", "unit", "flux", "pillar", "vector", "path", "shift", "pulse", "forge"]
@@ -1081,9 +1082,9 @@ class BrowsePage(PrivateLayoutView):
         elif val == 'unpopular':
             self.templates.sort(key=lambda x: x['usage_count'])
         elif val == 'alpha':
-            self.templates.sort(key=lambda x: x['prize'].lower())
+            self.templates = natsorted(self.templates, key=lambda x: x['prize'], alg=ns.IGNORECASE)
         elif val == 'revalpha':
-            self.templates.sort(key=lambda x: x['prize'].lower(), reverse=True)
+            self.templates = natsorted(self.templates, key=lambda x: x['prize'], alg=ns.IGNORECASE, reverse=True)
 
         self.page = 1
         self.filter_templates()

--- a/cogs/repeating_messages.py
+++ b/cogs/repeating_messages.py
@@ -6,12 +6,14 @@ import aiosqlite
 import asyncio
 import time
 import re
+import json
 from typing import Optional, List, Dict, Tuple, Any, AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from config import SMDB_PATH
 from dopamineframework import mod_check
 from dopamineframework import PrivateLayoutView
+from cogs.embed import UseEmbedPage
 
 
 class CreateRepeatingMessageModal(Modal):
@@ -63,6 +65,9 @@ class CreateRepeatingMessageModal(Modal):
             "name": self.name_input.value,
             "channel_id": self.channel.id,
             "message_content": self.content_input.value,
+            "response_type": "text",
+            "embed_content": None,
+            "embed_data": None,
             "frequency_seconds": frequency_seconds,
             "next_send_time": current_time,
             "is_active": 1,
@@ -73,9 +78,9 @@ class CreateRepeatingMessageModal(Modal):
             await db.execute(
                 """
                 INSERT INTO scheduled_messages
-                (guild_id, message_id, name, channel_id, message_content, frequency_seconds,
-                 next_send_time, is_active, started_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (guild_id, message_id, name, channel_id, message_content, response_type, embed_content, embed_data,
+                 frequency_seconds, next_send_time, is_active, started_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 tuple(data.values()),
             )
@@ -87,6 +92,88 @@ class CreateRepeatingMessageModal(Modal):
 
         await interaction.response.send_message(
             f"Successfully created **{data['name']}** in {self.channel.mention}!",
+            ephemeral=True
+        )
+        asyncio.create_task(self.cog.send_repeating_messages())
+
+
+class CreateRepeatingEmbedModal(Modal):
+    def __init__(
+        self,
+        cog: "RepeatingMessages",
+        channel: discord.TextChannel,
+        embed_content: Optional[str],
+        embed_data: Dict[str, Any],
+    ):
+        super().__init__(title=f"Create Message for #{channel.name}")
+        self.cog = cog
+        self.channel = channel
+        self.embed_content = embed_content
+        self.embed_data = embed_data
+
+        self.name_input = TextInput(
+            label="Name",
+            placeholder="Daily Reminder",
+            max_length=50,
+            required=True,
+        )
+        self.frequency_input = TextInput(
+            label="Frequency (Minimum 60 Sec.)",
+            placeholder="2w 7d 8hr 11m",
+            max_length=50,
+            required=True,
+        )
+        self.add_item(self.name_input)
+        self.add_item(self.frequency_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        frequency_seconds = self.cog.parse_frequency(self.frequency_input.value)
+
+        if frequency_seconds is None or frequency_seconds < 60:
+            await interaction.response.send_message(
+                "Error: Invalid frequency (Min 60s).", ephemeral=True
+            )
+            return
+
+        guild_id = interaction.guild_id
+        message_id = self.cog.get_next_message_id(guild_id)
+        current_time = time.time()
+
+        data = {
+            "guild_id": guild_id,
+            "message_id": message_id,
+            "name": self.name_input.value,
+            "channel_id": self.channel.id,
+            "message_content": None,
+            "response_type": "embed",
+            "embed_content": self.embed_content,
+            "embed_data": json.dumps(self.embed_data, ensure_ascii=False),
+            "frequency_seconds": frequency_seconds,
+            "next_send_time": current_time,
+            "is_active": 1,
+            "started_at": current_time
+        }
+
+        async with self.cog.acquire_db() as db:
+            await db.execute(
+                """
+                INSERT INTO scheduled_messages
+                (guild_id, message_id, name, channel_id, message_content, response_type, embed_content, embed_data,
+                 frequency_seconds, next_send_time, is_active, started_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                tuple(data.values()),
+            )
+            await db.commit()
+
+        if guild_id not in self.cog.message_cache:
+            self.cog.message_cache[guild_id] = {}
+        cached = dict(data)
+        cached["embed_data"] = self.embed_data
+        self.cog.message_cache[guild_id][message_id] = cached
+
+        await interaction.response.send_message(
+            f"Successfully created **{cached['name']}** in {self.channel.mention}!",
             ephemeral=True
         )
         asyncio.create_task(self.cog.send_repeating_messages())
@@ -112,14 +199,21 @@ class EditMessageContentModal(Modal):
         new_content = self.content_input.value
         async with self.cog.acquire_db() as db:
             await db.execute(
-                "UPDATE scheduled_messages SET message_content = ? WHERE guild_id = ? AND message_id = ?",
-                (new_content, self.guild_id, self.message_id)
+                "UPDATE scheduled_messages SET message_content = ?, response_type = ?, embed_content = NULL, embed_data = NULL "
+                "WHERE guild_id = ? AND message_id = ?",
+                (new_content, "text", self.guild_id, self.message_id)
             )
             await db.commit()
 
         self.cog.message_cache[self.guild_id][self.message_id]["message_content"] = new_content
+        self.cog.message_cache[self.guild_id][self.message_id]["response_type"] = "text"
+        self.cog.message_cache[self.guild_id][self.message_id]["embed_content"] = None
+        self.cog.message_cache[self.guild_id][self.message_id]["embed_data"] = None
 
         self.parent_view.panel_data["message_content"] = new_content
+        self.parent_view.panel_data["response_type"] = "text"
+        self.parent_view.panel_data["embed_content"] = None
+        self.parent_view.panel_data["embed_data"] = None
         self.parent_view.build_layout()
         await interaction.response.edit_message(view=self.parent_view)
 
@@ -225,8 +319,71 @@ class CreateChannelSelectView(PrivateLayoutView):
 
     async def select_callback(self, interaction: discord.Interaction):
         selected_channel = self.select.values[0]
-        modal = CreateRepeatingMessageModal(self.cog, selected_channel)
-        await interaction.response.send_modal(modal)
+        view = RepeatingResponseTypeView(self.user, self.cog, selected_channel)
+        await interaction.response.edit_message(view=view)
+
+
+class RepeatingResponseTypeView(PrivateLayoutView):
+    def __init__(self, user, cog: "RepeatingMessages", channel: discord.TextChannel):
+        super().__init__(user, timeout=None)
+        self.cog = cog
+        self.channel = channel
+        self.build_layout()
+
+    def build_layout(self):
+        self.clear_items()
+        container = discord.ui.Container()
+        container.add_item(discord.ui.TextDisplay("### Step 2: Select the response type"))
+        container.add_item(discord.ui.Separator())
+
+        text_btn = discord.ui.Button(label="Text", style=discord.ButtonStyle.primary)
+        embed_btn = discord.ui.Button(label="Embed", style=discord.ButtonStyle.primary)
+
+        async def choose_text(interaction: discord.Interaction):
+            modal = CreateRepeatingMessageModal(self.cog, self.channel)
+            await interaction.response.send_modal(modal)
+
+        async def choose_embed(interaction: discord.Interaction):
+            embeds_cog = self.cog.bot.get_cog("Embeds")
+            if embeds_cog is None:
+                await interaction.response.send_message(
+                    "Embed system is not available right now. Please try again later.", ephemeral=True
+                )
+                return
+
+            embeds = await embeds_cog.fetch_embeds_for_guild(interaction.guild.id)
+            if not embeds:
+                await interaction.response.send_message(
+                    "No saved embeds found for this server. Use `/embed` to create one first.", ephemeral=True
+                )
+                return
+
+            async def on_pick(inter: discord.Interaction, content: Optional[str], embed_obj: discord.Embed):
+                modal = CreateRepeatingEmbedModal(
+                    self.cog,
+                    self.channel,
+                    content or None,
+                    embed_obj.to_dict(),
+                )
+                await inter.response.send_modal(modal)
+
+            view = UseEmbedPage(
+                user=self.user,
+                cog=embeds_cog,
+                guild_id=interaction.guild.id,
+                embeds=embeds,
+                returnembed=True,
+                on_pick=on_pick,
+            )
+            await interaction.response.edit_message(view=view)
+
+        text_btn.callback = choose_text
+        embed_btn.callback = choose_embed
+        row = discord.ui.ActionRow()
+        row.add_item(text_btn)
+        row.add_item(embed_btn)
+        container.add_item(row)
+        self.add_item(container)
 
 class ChannelSelectView(PrivateLayoutView):
     def __init__(self, user, cog, guild_id, message_id, previous_view):
@@ -445,7 +602,8 @@ class EditPage(PrivateLayoutView):
             f"**Channel:** <#{self.panel_data['channel_id']}>\n"
             f"**Frequency:** {fmt_freq}\n"
             f"**Next Send:** {timestamp_str}\n"
-            f"**Message Content:**\n```\n{self.panel_data['message_content'][:1500]}\n```"
+            f"**Response Type:** {('Embed' if self.panel_data.get('response_type') == 'embed' else 'Text')}\n"
+            f"**Message Content:**\n```\n{(self.panel_data.get('message_content') or self.panel_data.get('embed_content') or '*None*')[:1500]}\n```"
         )
         container.add_item(discord.ui.TextDisplay(details))
         container.add_item(discord.ui.Separator())
@@ -458,7 +616,9 @@ class EditPage(PrivateLayoutView):
         btn_state = discord.ui.Button(label=btn_state_label, style=btn_state_style)
         btn_state.callback = self.toggle_state_callback
 
-        btn_edit_message = discord.ui.Button(label="Edit Message Content", style=discord.ButtonStyle.secondary)
+        edit_label = "Refresh Embed" if self.panel_data.get('response_type') == 'embed' else "Edit Response"
+        edit_style = discord.ButtonStyle.primary if self.panel_data.get('response_type') == 'embed' else discord.ButtonStyle.secondary
+        btn_edit_message = discord.ui.Button(label=edit_label, style=edit_style)
         btn_edit_message.callback = self.edit_message_callback
 
         btn_edit_channel = discord.ui.Button(label="Edit Channel", style=discord.ButtonStyle.secondary)
@@ -515,9 +675,53 @@ class EditPage(PrivateLayoutView):
         await interaction.response.edit_message(view=self)
 
     async def edit_message_callback(self, interaction: discord.Interaction):
+        if self.panel_data.get("response_type") == "embed":
+            embeds_cog = self.cog.bot.get_cog("Embeds")
+            if embeds_cog is None:
+                await interaction.response.send_message(
+                    "Embed system is not available right now. Please try again later.", ephemeral=True
+                )
+                return
+
+            embeds = await embeds_cog.fetch_embeds_for_guild(interaction.guild.id)
+            if not embeds:
+                await interaction.response.send_message(
+                    "No saved embeds found for this server. Use `/embed` to create one first.", ephemeral=True
+                )
+                return
+
+            async def on_pick(inter: discord.Interaction, content: Optional[str], embed_obj: discord.Embed):
+                raw_embed = json.dumps(embed_obj.to_dict(), ensure_ascii=False)
+                async with self.cog.acquire_db() as db:
+                    await db.execute(
+                        "UPDATE scheduled_messages SET response_type = ?, message_content = NULL, embed_content = ?, embed_data = ? "
+                        "WHERE guild_id = ? AND message_id = ?",
+                        ("embed", content or None, raw_embed, self.guild_id, self.panel_data["message_id"]),
+                    )
+                    await db.commit()
+                cache_item = self.cog.message_cache[self.guild_id][self.panel_data["message_id"]]
+                cache_item["response_type"] = "embed"
+                cache_item["message_content"] = None
+                cache_item["embed_content"] = content or None
+                cache_item["embed_data"] = embed_obj.to_dict()
+                self.panel_data = cache_item
+                self.build_layout()
+                await inter.response.edit_message(view=self)
+
+            view = UseEmbedPage(
+                user=self.user,
+                cog=embeds_cog,
+                guild_id=interaction.guild.id,
+                embeds=embeds,
+                returnembed=True,
+                on_pick=on_pick,
+            )
+            await interaction.response.edit_message(view=view)
+            return
+
         modal = EditMessageContentModal(
             self.cog, self.guild_id, self.panel_data['message_id'],
-            self.panel_data['message_content'], self
+            self.panel_data.get('message_content') or "", self
         )
         await interaction.response.send_modal(modal)
 
@@ -690,6 +894,15 @@ class RepeatingMessages(commands.Cog):
                     )
                 """
             )
+            for sql in (
+                "ALTER TABLE scheduled_messages ADD COLUMN response_type TEXT DEFAULT 'text'",
+                "ALTER TABLE scheduled_messages ADD COLUMN embed_content TEXT",
+                "ALTER TABLE scheduled_messages ADD COLUMN embed_data TEXT",
+            ):
+                try:
+                    await db.execute(sql)
+                except Exception:
+                    pass
             await db.execute(
                 "CREATE INDEX IF NOT EXISTS idx_sm_active ON scheduled_messages(is_active, next_send_time)")
             await db.commit()
@@ -702,6 +915,14 @@ class RepeatingMessages(commands.Cog):
                 columns = [column[0] for column in cursor.description]
                 for row in rows:
                     data = dict(zip(columns, row))
+                    if data.get("response_type") is None:
+                        data["response_type"] = "text"
+                    raw_embed = data.get("embed_data")
+                    if raw_embed:
+                        try:
+                            data["embed_data"] = json.loads(raw_embed)
+                        except Exception:
+                            data["embed_data"] = None
                     g_id = data["guild_id"]
                     m_id = data["message_id"]
 
@@ -778,7 +999,11 @@ class RepeatingMessages(commands.Cog):
                     try:
                         channel = self.bot.get_channel(data["channel_id"]) or await self.bot.fetch_channel(data["channel_id"])
                         if channel:
-                            await channel.send(data["message_content"])
+                            if data.get("response_type") == "embed" and data.get("embed_data"):
+                                embed_obj = discord.Embed.from_dict(data["embed_data"])
+                                await channel.send(content=data.get("embed_content"), embed=embed_obj)
+                            else:
+                                await channel.send(data.get("message_content"))
 
                         new_next_send = now + data["frequency_seconds"]
 

--- a/cogs/repeating_messages.py
+++ b/cogs/repeating_messages.py
@@ -616,7 +616,7 @@ class EditPage(PrivateLayoutView):
         btn_state = discord.ui.Button(label=btn_state_label, style=btn_state_style)
         btn_state.callback = self.toggle_state_callback
 
-        edit_label = "Refresh Embed" if self.panel_data.get('response_type') == 'embed' else "Edit Response"
+        edit_label = "Edit Embed" if self.panel_data.get('response_type') == 'embed' else "Edit Response"
         edit_style = discord.ButtonStyle.primary if self.panel_data.get('response_type') == 'embed' else discord.ButtonStyle.secondary
         btn_edit_message = discord.ui.Button(label=edit_label, style=edit_style)
         btn_edit_message.callback = self.edit_message_callback

--- a/cogs/sticky_messages.py
+++ b/cogs/sticky_messages.py
@@ -3,12 +3,14 @@ import discord
 from discord.ext import commands, tasks
 from discord import app_commands
 import aiosqlite
+import json
 from typing import Optional, Dict, List, Any
 import time
 from contextlib import asynccontextmanager
 from dopamineframework import PrivateLayoutView
 from config import STICKYDB_PATH
 from dopamineframework import mod_check
+from cogs.embed import UseEmbedPage
 
 
 
@@ -119,18 +121,29 @@ class EditPage(PrivateLayoutView):
         container.add_item(discord.ui.Separator())
 
         bots_enabled = p.get('include_bots', 1) == 1
+        is_embed_response = p.get("response_type") == "embed"
+        response_label = "Embed" if is_embed_response else "Text"
+        response_preview = (p.get("embed_content") if is_embed_response else p.get("response_text")) or "*None*"
         details = (
             f"**Channel:** <#{p['channel_id']}>\n"
+            f"**Response Type:** `{response_label}`\n"
             f"**Color:** `{p.get('embed_color') or 'Default'}`\n"
             f"**Conversation Duration:** `{p.get('conversation_duration', 10)}s`\n"
             f"**Include Bots:** `{'Yes' if bots_enabled else 'No'}`\n"
+            f"**Response Content:** ```{response_preview}```\n"
             f"**Description:** ```{p.get('description') or '*None*'}```"
         )
         container.add_item(discord.ui.TextDisplay(details))
         container.add_item(discord.ui.Separator())
 
         row1 = discord.ui.ActionRow()
-        btn_edit_message = discord.ui.Button(label="Edit Message", style=discord.ButtonStyle.secondary)
+        if p.get("response_type") == "embed":
+            msg_label = "Refresh Embed"
+            msg_style = discord.ButtonStyle.primary
+        else:
+            msg_label = "Edit Response"
+            msg_style = discord.ButtonStyle.secondary
+        btn_edit_message = discord.ui.Button(label=msg_label, style=msg_style)
         btn_edit_message.callback = self.edit_message_callback
         btn_edit_channel = discord.ui.Button(label="Edit Channel", style=discord.ButtonStyle.secondary)
         btn_edit_channel.callback = self.edit_channel_callback
@@ -159,6 +172,64 @@ class EditPage(PrivateLayoutView):
         self.add_item(container)
 
     async def edit_message_callback(self, interaction: discord.Interaction):
+        if self.panel_data.get("response_type") == "text":
+            modal = StickyTextSetupModal(
+                self.cog,
+                self.guild_id,
+                self.panel_data['channel_id'],
+                is_edit=True,
+                original_title=self.panel_data['title'],
+            )
+            await interaction.response.send_modal(modal)
+            return
+
+        if self.panel_data.get("response_type") == "embed":
+            embeds_cog = self.cog.bot.get_cog("Embeds")
+            if embeds_cog is None:
+                await interaction.response.send_message(
+                    "Embed system is not available right now. Please try again later.",
+                    ephemeral=True,
+                )
+                return
+
+            embeds = await embeds_cog.fetch_embeds_for_guild(interaction.guild.id)
+            if not embeds:
+                await interaction.response.send_message(
+                    "No saved embeds found for this server. Use `/embed` to create one first.",
+                    ephemeral=True,
+                )
+                return
+
+            async def on_pick(inter: discord.Interaction, content: Optional[str], embed_obj: discord.Embed):
+                raw_embed = json.dumps(embed_obj.to_dict(), ensure_ascii=False)
+                title = self.panel_data["title"]
+                async with self.cog.acquire_db() as db:
+                    await db.execute(
+                        "UPDATE sticky_panels SET response_type = ?, response_text = NULL, embed_content = ?, embed_data = ? "
+                        "WHERE guild_id = ? AND title = ?",
+                        ("embed", content or None, raw_embed, self.guild_id, title),
+                    )
+                    await db.commit()
+
+                panel = self.cog.panel_cache[self.guild_id][title]
+                panel["response_type"] = "embed"
+                panel["response_text"] = None
+                panel["embed_content"] = content or None
+                panel["embed_data"] = embed_obj.to_dict()
+                self.panel_data = panel
+                self.build_layout()
+                await inter.response.edit_message(view=self)
+            view = UseEmbedPage(
+                user=self.user,
+                cog=embeds_cog,
+                guild_id=interaction.guild.id,
+                embeds=embeds,
+                returnembed=True,
+                on_pick=on_pick,
+            )
+            await interaction.response.edit_message(view=view)
+            return
+
         modal = StickySetupModal(self.cog, self.guild_id, self.panel_data['channel_id'], is_edit=True,
                                  original_title=self.panel_data['title'])
         await interaction.response.send_modal(modal)
@@ -362,6 +433,17 @@ class ChannelSelectView(PrivateLayoutView):
     async def select_callback(self, interaction: discord.Interaction):
         selected_channel = self.select.values[0]
 
+        if selected_channel.id in self.cog.active_channels:
+            existing_panel = self.cog.active_channels[selected_channel.id]
+
+            is_different_sticky = not self.is_rebind or (existing_panel['title'] != self.panel_title)
+
+            if is_different_sticky:
+                return await interaction.response.send_message(
+                    f"The channel {selected_channel.mention} already has a sticky message named **{existing_panel['title']}**.\n"
+                    f"A channel can only have one sticky message at a time.",
+                    ephemeral=True
+                )
         if self.is_rebind:
             panel = self.cog.panel_cache[self.guild_id][self.panel_title]
             old_channel_id = panel['channel_id']
@@ -386,8 +468,72 @@ class ChannelSelectView(PrivateLayoutView):
                 await self.cog.update_sticky_message(panel, new_channel)
 
         else:
-            modal = StickySetupModal(self.cog, self.guild_id, selected_channel.id, is_edit=False)
+            view = StickyResponseTypeView(self.user, self.cog, self.guild_id, selected_channel.id)
+            await interaction.response.edit_message(view=view)
+
+
+class StickyResponseTypeView(PrivateLayoutView):
+    def __init__(self, user, cog, guild_id: int, channel_id: int):
+        super().__init__(user, timeout=None)
+        self.cog = cog
+        self.guild_id = guild_id
+        self.channel_id = channel_id
+        self.build_layout()
+
+    def build_layout(self):
+        self.clear_items()
+        container = discord.ui.Container()
+        container.add_item(discord.ui.TextDisplay("### Step 2: Select response type"))
+        container.add_item(discord.ui.Separator())
+        text_btn = discord.ui.Button(label="Text", style=discord.ButtonStyle.primary)
+        embed_btn = discord.ui.Button(label="Embed", style=discord.ButtonStyle.primary)
+
+        async def choose_text(interaction: discord.Interaction):
+            modal = StickyTextSetupModal(self.cog, self.guild_id, self.channel_id, is_edit=False)
             await interaction.response.send_modal(modal)
+
+        async def choose_embed(interaction: discord.Interaction):
+            embeds_cog = self.cog.bot.get_cog("Embeds")
+            if embeds_cog is None:
+                await interaction.response.send_message(
+                    "Embed system is not available right now. Please try again later.", ephemeral=True
+                )
+                return
+
+            embeds = await embeds_cog.fetch_embeds_for_guild(interaction.guild.id)
+            if not embeds:
+                await interaction.response.send_message(
+                    "No saved embeds found for this server. Use `/embed` to create one first.", ephemeral=True
+                )
+                return
+
+            async def on_pick(inter: discord.Interaction, content: Optional[str], embed_obj: discord.Embed):
+                modal = StickyEmbedNameModal(
+                    self.cog,
+                    self.guild_id,
+                    self.channel_id,
+                    content or None,
+                    embed_obj.to_dict(),
+                )
+                await inter.response.send_modal(modal)
+
+            view = UseEmbedPage(
+                user=self.user,
+                cog=embeds_cog,
+                guild_id=interaction.guild.id,
+                embeds=embeds,
+                returnembed=True,
+                on_pick=on_pick,
+            )
+            await interaction.response.edit_message(view=view)
+
+        text_btn.callback = choose_text
+        embed_btn.callback = choose_embed
+        row = discord.ui.ActionRow()
+        row.add_item(text_btn)
+        row.add_item(embed_btn)
+        container.add_item(row)
+        self.add_item(container)
 
 
 class StickyDashboard(PrivateLayoutView):
@@ -488,6 +634,154 @@ class DurationModal(discord.ui.Modal):
         await interaction.response.edit_message(view=self.parent_view)
 
 
+class StickyTextSetupModal(discord.ui.Modal):
+    def __init__(self, cog, guild_id, channel_id, is_edit=False, original_title=None):
+        super().__init__(title="Configure Sticky Text Response")
+        self.cog = cog
+        self.guild_id = guild_id
+        self.channel_id = channel_id
+        self.is_edit = is_edit
+        self.original_title = original_title
+
+        self.title_input = discord.ui.TextInput(label="Sticky Name (Identifier)", default=original_title or "", required=True)
+        self.response_input = discord.ui.TextInput(
+            label="Text Response",
+            style=discord.TextStyle.paragraph,
+            required=True,
+            max_length=2000,
+        )
+        self.add_item(self.title_input)
+        self.add_item(self.response_input)
+
+        if is_edit:
+            data = cog.panel_cache[guild_id].get(original_title, {})
+            self.response_input.default = data.get("response_text", "")
+
+    async def on_submit(self, interaction: discord.Interaction):
+        title = self.title_input.value.strip()
+        response_text = self.response_input.value
+
+        if not title:
+            await interaction.response.send_message("Sticky name is required.", ephemeral=True)
+            return
+
+        if not self.is_edit and title in self.cog.panel_cache.get(self.guild_id, {}):
+            await interaction.response.send_message("A sticky message with that title already exists.", ephemeral=True)
+            return
+
+        if self.is_edit:
+            panel = self.cog.panel_cache[self.guild_id].get(self.original_title)
+            if panel is None:
+                await interaction.response.send_message("Sticky message not found.", ephemeral=True)
+                return
+
+            async with self.cog.acquire_db() as db:
+                await db.execute(
+                    "UPDATE sticky_panels SET title = ?, response_type = ?, response_text = ?, embed_content = NULL, embed_data = NULL "
+                    "WHERE guild_id = ? AND title = ?",
+                    (title, "text", response_text, self.guild_id, self.original_title),
+                )
+                await db.commit()
+
+            panel["title"] = title
+            panel["response_type"] = "text"
+            panel["response_text"] = response_text
+            panel["embed_content"] = None
+            panel["embed_data"] = None
+
+            if title != self.original_title:
+                self.cog.panel_cache[self.guild_id][title] = self.cog.panel_cache[self.guild_id].pop(self.original_title)
+            self.cog.active_channels[panel["channel_id"]] = panel
+            await interaction.response.send_message(f"Sticky message **{title}** updated!", ephemeral=True)
+            return
+
+        data = {
+            "guild_id": self.guild_id,
+            "title": title,
+            "embed_color": None,
+            "description": None,
+            "image_url": None,
+            "footer": None,
+            "channel_id": self.channel_id,
+            "last_message_id": None,
+            "conversation_duration": 10,
+            "include_bots": 1,
+            "panel_id": int(time.time()),
+            "response_type": "text",
+            "response_text": response_text,
+            "embed_content": None,
+            "embed_data": None,
+        }
+
+        async with self.cog.acquire_db() as db:
+            cols = ", ".join(data.keys())
+            placeholders = ", ".join(["?"] * len(data))
+            await db.execute(f"INSERT INTO sticky_panels ({cols}) VALUES ({placeholders})", list(data.values()))
+            await db.commit()
+
+        self.cog.panel_cache.setdefault(self.guild_id, {})[title] = data
+        self.cog.active_channels[self.channel_id] = data
+        channel = self.cog.bot.get_channel(self.channel_id) or await self.cog.bot.fetch_channel(self.channel_id)
+        if channel:
+            await self.cog.update_sticky_message(data, channel)
+        await interaction.response.send_message(f"Sticky message **{title}** created!", ephemeral=True)
+
+
+class StickyEmbedNameModal(discord.ui.Modal):
+    def __init__(self, cog, guild_id, channel_id, embed_content: Optional[str], embed_data: Dict[str, Any]):
+        super().__init__(title="Name Sticky Embed Response")
+        self.cog = cog
+        self.guild_id = guild_id
+        self.channel_id = channel_id
+        self.embed_content = embed_content
+        self.embed_data = embed_data
+        self.title_input = discord.ui.TextInput(label="Sticky Name (Identifier)", required=True, max_length=100)
+        self.add_item(self.title_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        title = self.title_input.value.strip()
+        if not title:
+            await interaction.response.send_message("Sticky name is required.", ephemeral=True)
+            return
+        if title in self.cog.panel_cache.get(self.guild_id, {}):
+            await interaction.response.send_message("A sticky message with that title already exists.", ephemeral=True)
+            return
+
+        data = {
+            "guild_id": self.guild_id,
+            "title": title,
+            "embed_color": None,
+            "description": None,
+            "image_url": None,
+            "footer": None,
+            "channel_id": self.channel_id,
+            "last_message_id": None,
+            "conversation_duration": 10,
+            "include_bots": 1,
+            "panel_id": int(time.time()),
+            "response_type": "embed",
+            "response_text": None,
+            "embed_content": self.embed_content,
+            "embed_data": json.dumps(self.embed_data, ensure_ascii=False),
+        }
+
+        async with self.cog.acquire_db() as db:
+            cols = ", ".join(data.keys())
+            placeholders = ", ".join(["?"] * len(data))
+            await db.execute(f"INSERT INTO sticky_panels ({cols}) VALUES ({placeholders})", list(data.values()))
+            await db.commit()
+
+        cache_data = dict(data)
+        cache_data["embed_data"] = self.embed_data
+        self.cog.panel_cache.setdefault(self.guild_id, {})[title] = cache_data
+        self.cog.active_channels[self.channel_id] = cache_data
+
+        channel = self.cog.bot.get_channel(self.channel_id) or await self.cog.bot.fetch_channel(self.channel_id)
+        if channel:
+            await self.cog.update_sticky_message(cache_data, channel)
+        await interaction.response.send_message(f"Sticky message **{title}** created!", ephemeral=True)
+
+
 class StickySetupModal(discord.ui.Modal):
     def __init__(self, cog, guild_id, channel_id, is_edit=False, original_title=None):
         super().__init__(title="Configure Sticky Message")
@@ -546,10 +840,8 @@ class StickySetupModal(discord.ui.Modal):
 
         async with self.cog.acquire_db() as db:
             if self.is_edit:
-                # Get the existing reference so we update the object everywhere
                 panel = self.cog.panel_cache[self.guild_id].get(self.original_title)
 
-                # Update the actual dictionary object that active_channels is also pointing to
                 panel.update({
                     "title": title,
                     "embed_color": color_val or None,
@@ -558,7 +850,6 @@ class StickySetupModal(discord.ui.Modal):
                     "footer": self.footer_input.value or None,
                 })
 
-                # Handle title change in the nested dict
                 if title != self.original_title:
                     self.cog.panel_cache[self.guild_id][title] = self.cog.panel_cache[self.guild_id].pop(
                         self.original_title)
@@ -642,6 +933,16 @@ class StickyMessages(commands.Cog):
                 image_url TEXT, embed_color TEXT, channel_id INTEGER, last_message_id INTEGER,
                 conversation_duration INTEGER DEFAULT 10, include_bots INTEGER DEFAULT 1,
                 PRIMARY KEY (guild_id, panel_id))''')
+            for sql in (
+                "ALTER TABLE sticky_panels ADD COLUMN response_type TEXT DEFAULT 'embed'",
+                "ALTER TABLE sticky_panels ADD COLUMN response_text TEXT",
+                "ALTER TABLE sticky_panels ADD COLUMN embed_content TEXT",
+                "ALTER TABLE sticky_panels ADD COLUMN embed_data TEXT",
+            ):
+                try:
+                    await db.execute(sql)
+                except Exception:
+                    pass
             await db.commit()
 
     async def populate_caches(self):
@@ -651,6 +952,14 @@ class StickyMessages(commands.Cog):
                 cols = [c[0] for c in cursor.description]
                 for r in rows:
                     d = dict(zip(cols, r))
+                    if d.get("response_type") is None:
+                        d["response_type"] = "embed"
+                    raw_embed = d.get("embed_data")
+                    if raw_embed:
+                        try:
+                            d["embed_data"] = json.loads(raw_embed)
+                        except Exception:
+                            d["embed_data"] = None
                     self.panel_cache.setdefault(d["guild_id"], {})[d["title"]] = d
                     if d["channel_id"]: self.active_channels[d["channel_id"]] = d
 
@@ -718,7 +1027,13 @@ class StickyMessages(commands.Cog):
                     await (await channel.fetch_message(panel['last_message_id'])).delete()
                 except:
                     pass
-            new_msg = await channel.send(embed=self.build_panel_embed(panel))
+            if panel.get("response_type") == "text":
+                new_msg = await channel.send(panel.get("response_text") or "")
+            elif panel.get("response_type") == "embed" and panel.get("embed_data"):
+                embed_obj = discord.Embed.from_dict(panel.get("embed_data"))
+                new_msg = await channel.send(content=panel.get("embed_content"), embed=embed_obj)
+            else:
+                new_msg = await channel.send(embed=self.build_panel_embed(panel))
             async with self.acquire_db() as db:
                 await db.execute("UPDATE sticky_panels SET last_message_id = ? WHERE guild_id = ? AND title = ?",
                                  (new_msg.id, panel['guild_id'], panel['title']))

--- a/cogs/sticky_messages.py
+++ b/cogs/sticky_messages.py
@@ -127,18 +127,16 @@ class EditPage(PrivateLayoutView):
         details = (
             f"**Channel:** <#{p['channel_id']}>\n"
             f"**Response Type:** `{response_label}`\n"
-            f"**Color:** `{p.get('embed_color') or 'Default'}`\n"
             f"**Conversation Duration:** `{p.get('conversation_duration', 10)}s`\n"
             f"**Include Bots:** `{'Yes' if bots_enabled else 'No'}`\n"
-            f"**Response Content:** ```{response_preview}```\n"
-            f"**Description:** ```{p.get('description') or '*None*'}```"
+            f"**Response Content:** ```{response_preview}```"
         )
         container.add_item(discord.ui.TextDisplay(details))
         container.add_item(discord.ui.Separator())
 
         row1 = discord.ui.ActionRow()
         if p.get("response_type") == "embed":
-            msg_label = "Refresh Embed"
+            msg_label = "Edit Embed"
             msg_style = discord.ButtonStyle.primary
         else:
             msg_label = "Edit Response"

--- a/cogs/uptimemonitor.py
+++ b/cogs/uptimemonitor.py
@@ -28,7 +28,8 @@ class StatusHeartbeat(commands.Cog):
                 if response.status != 200:
                     self.bot.logger.warning(f"Heartbeat failed: Status {response.status}")
         except Exception as e:
-            self.bot.logger.error(f"Heartbeat loop error: {e}")
+            if self.bot and hasattr(self.bot, 'logger'):
+                self.bot.logger.error(f"Heartbeat loop error: {e}")
             if self.session:
                 await self.session.close()
 
@@ -38,7 +39,8 @@ class StatusHeartbeat(commands.Cog):
 
     @send_heartbeat.error
     async def on_heartbeat_error(self, error):
-        self.bot.logger.critical(f"The heartbeat task has DIED: {error}")
+        if self.bot and hasattr(self.bot, 'logger'):
+            self.bot.logger.critical(f"The heartbeat task has DIED: {error}")
 
         if self.bot.owner_ids:
             owners = list(self.bot.owner_ids)
@@ -56,8 +58,10 @@ class StatusHeartbeat(commands.Cog):
                 owner = self.bot.get_user(owner_id) or await self.bot.fetch_user(owner_id)
                 await owner.send(f"**Critical:** The heartbeat task has failed: ```{error}```")
             except Exception as e:
-                self.bot.logger.error(f"Could not send DM to owner {owner_id}: {e}")
-        self.send_heartbeat.restart()
+                    if self.bot and hasattr(self.bot, 'logger'):
+                        self.bot.logger.error(f"Could not send DM to owner {owner_id}: {e}")
+            if not self.send_heartbeat.is_being_cancelled():
+                self.send_heartbeat.restart()
 
 async def setup(bot):
     await bot.add_cog(StatusHeartbeat(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz==2025.2
 python-dotenv==1.2.1
 RapidFuzz==3.14.3
 setuptools==81.0.0
+natsort==8.4.0


### PR DESCRIPTION
# v3.9.0 - Improved Sticky Messages and Repeating Messages!

### Updates & Changes
* Switched to word boundary approach for partial match in Autoresponse instead of substring. Before, if the trigger is "hi", the response would be triggered by words like "think". Now, "hi" must be a standalone word.
* Simplified "Alert from the Developer at Dopamine Studios" to "Alert from the Developer" in alert message.
* Missed Pings message in AFK feature is now sent through a DM because ephemeral messages aren't reliable on Discord mobile, so if the message disappears, the user could never see the missed pings again because they got cleared.
* Added support for choosing between text and embed type responses in Sticky Messages. Integrated with embed manager for embeds.
* Simplified embed save message.
* Added header markdown in Save & Send button of embed manager to match other channel select.
* Added support for choosing between text and embed type responses in Repeating Messages. Integrated with embed manager for embeds.
* Added ability to edit response message in Autoresponse.

### Fixes
* Fixed alphabetical sorting in Giveaway Browse page by using natsort library.
* Fixed (or removed) the useless embed in "connected" message in DiscordPhone.
* Fixed bug where [AFK] tag wasn't removed from a user's name after they came back.
* Fixed crash in uptime monitor when bot is being closed.

<sub>For even more detailed changelogs, you can read the Git commit history by [clicking here](https://github.com/likerofturtles/dopamine/commits/main/).