### PR TITLE
v4.1.0 - An update so generic that we can't name it

### DIFF
--- a/VERSION.py
+++ b/VERSION.py
@@ -1,1 +1,1 @@
-bot_version = "v4.0.1"
+bot_version = "v4.1.0"

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -12,6 +12,7 @@ from config import AFKDB_PATH
 from beacon import ViewPaginator, PrivateView
 from utils.data_handlers import export_table
 from utils.data_protocol import DataDeleteResult, DataExportChunk, DataFeatureMeta, DataMonitorResult
+import datetime
 
 AFK_BUFFER_SECONDS = 30
 AFK_MAX_SECONDS = 72 * 60 * 60
@@ -41,6 +42,121 @@ class MissedPing:
     timestamp: int
 
 
+class GoToPageModal(discord.ui.Modal, title="Go to Page"):
+    page_input = discord.ui.TextInput(
+        label="Enter page number",
+        placeholder="e.g. 2",
+        min_length=1,
+        max_length=5
+    )
+
+    def __init__(self, paginator: "MissedPingsPaginator"):
+        super().__init__()
+        self.paginator = paginator
+        self.page_input.label = f"Enter page number (1-{paginator.total_pages})"
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            page = int(self.page_input.value)
+            if 1 <= page <= self.paginator.total_pages:
+                self.paginator.current_page = page
+                await self.paginator.update_message(interaction)
+            else:
+                await interaction.response.send_message(
+                    f"Invalid page number. Please enter a value between 1 and {self.paginator.total_pages}.",
+                    ephemeral=True
+                )
+        except ValueError:
+            await interaction.response.send_message(
+                "Please enter a valid whole number for the page number.",
+                ephemeral=True
+            )
+
+
+class MissedPingsPaginator(discord.ui.View):
+    def __init__(self, interaction: discord.Interaction, entries: list[MissedPing], cog: "AFK"):
+        super().__init__(timeout=180)
+        self.interaction = interaction
+        self.entries = entries
+        self.cog = cog
+        self.current_page = 1
+        self.per_page = 5
+        self.total_pages = (len(entries) + self.per_page - 1) // self.per_page
+        self.message: discord.Message | None = None
+        self.update_buttons()
+
+    def update_buttons(self):
+        self.prev_page.disabled = self.current_page == 1
+        self.go_to_page.disabled = self.total_pages == 1
+        self.go_to_page.label = f"Page {self.current_page} of {self.total_pages}"
+        self.next_page.disabled = self.current_page == self.total_pages
+
+    async def get_page_embeds(self) -> list[discord.Embed]:
+        start = (self.current_page - 1) * self.per_page
+        end = start + self.per_page
+        page_entries = self.entries[start:end]
+        embeds = []
+
+        for entry in page_entries:
+            guild = self.interaction.client.get_guild(entry.guild_id) if entry.guild_id else None
+            member = guild.get_member(entry.author_id) if guild else None
+            user = member or self.interaction.client.get_user(entry.author_id)
+            if not user:
+                try:
+                    user = await self.interaction.client.fetch_user(entry.author_id)
+                except discord.HTTPException:
+                    user = None
+
+            display_name = user.display_name if user else f"User {entry.author_id}"
+            avatar_url = user.display_avatar.url if user else None
+
+            embed = discord.Embed(colour=discord.Colour(0x944ae8))
+            embed.set_author(name=display_name, icon_url=avatar_url)
+
+            jump_link = f"[Click here to Jump](https://discord.com/channels/{entry.guild_id or '@me'}/{entry.channel_id or 0}/{entry.message_id or 0})"
+            content = entry.content
+            if len(content) > 1000:
+                content = content[:1000] + "..."
+
+            embed.description = f"{jump_link}\n\n{content}"
+            embed.set_footer(text=f"in {guild.name if guild else 'Unknown Server'}")
+            embed.timestamp = datetime.datetime.fromtimestamp(entry.timestamp, tz=datetime.timezone.utc).replace(tzinfo=None)
+            embeds.append(embed)
+
+        return embeds
+
+    async def send_initial(self) -> bool:
+        embeds = await self.get_page_embeds()
+        content = f"# {len(self.entries)} Missed Pings"
+        try:
+            self.message = await self.interaction.user.send(content=content, embeds=embeds, view=self)
+            return True
+        except discord.Forbidden:
+            return False
+
+    async def update_message(self, interaction: discord.Interaction):
+        self.update_buttons()
+        embeds = await self.get_page_embeds()
+        content = f"# {len(self.entries)} Missed Pings"
+        await interaction.response.edit_message(content=content, embeds=embeds, view=self)
+
+    @discord.ui.button(label="◀", style=discord.ButtonStyle.primary)
+    async def prev_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if self.current_page > 1:
+            self.current_page -= 1
+            await self.update_message(interaction)
+
+    @discord.ui.button(style=discord.ButtonStyle.secondary)
+    async def go_to_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(GoToPageModal(self))
+
+    @discord.ui.button(label="▶", style=discord.ButtonStyle.primary)
+    async def next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if self.current_page < self.total_pages:
+            self.current_page += 1
+            await self.update_message(interaction)
+
+
 class ViewMissedPings(PrivateView):
     def __init__(self, cog: "AFK", user_id: int, user: discord.User | discord.Member,
                  string_for_after_missed_pings_clear: str):
@@ -57,47 +173,18 @@ class ViewMissedPings(PrivateView):
         if not entries:
             return await interaction.response.send_message("You have no missed pings.", ephemeral=True)
 
-        lines: List[str] = []
-        for idx, entry in enumerate(entries, start=1):
-            guild = interaction.client.get_guild(entry.guild_id) if entry.guild_id else None
-            member = guild.get_member(entry.author_id) if guild else None
-            user = member or interaction.client.get_user(entry.author_id) or await interaction.client.fetch_user(
-                entry.author_id)
-            display_name = user.mention or (user.name if user else f"User {entry.author_id}")
-            msg_link = ""
-            if entry.guild_id and entry.channel_id and entry.message_id:
-                msg_link = f" [[Jump]](<https://discord.com/channels/{entry.guild_id}/{entry.channel_id}/{entry.message_id}>)"
-
-            lines.append(
-                f'{idx}. {display_name} in **{guild.name}**'
-                f'(<t:{entry.timestamp}:d> <t:{entry.timestamp}:t>): '
-                f'"{entry.content}"{msg_link}\n\n'
-            )
-
-        paginator = ViewPaginator(
-            title=f"{len(entries)} Missed Pings",
-            data=lines,
-            per_page=5,
-            color=discord.Color(0x944ae8),
-        )
-        try:
-            message = await interaction.user.send(
-                embed=paginator.format_embed(),
-                view=paginator
-            )
-            link = message.jump_url
-            sent = True
-        except discord.Forbidden:
-            await interaction.response.send_message(
-                """I can't DM you the Missed Pings! Please first DM me "hi" so that Discord lets me DM you.""",
-                ephemeral=True)
-            sent = False
+        paginator = MissedPingsPaginator(interaction, entries, self.cog)
+        sent = await paginator.send_initial()
 
         if sent:
             await interaction.response.send_message(
-                f"I sent the Missed Pings to your DMs! [Click here to Jump]({link}).", ephemeral=True)
+                f"I sent the Missed Pings to your DMs! [Click here to Jump]({paginator.message.jump_url}).", ephemeral=True)
             await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
             await self.cog.clear_missed_pings(self.user_id)
+        else:
+            await interaction.response.send_message(
+                """I can't DM you the Missed Pings! Please first DM me "hi" so that Discord lets me DM you.""",
+                ephemeral=True)
 
     async def on_timeout(self) -> None:
         if self.message:

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -42,7 +42,8 @@ class MissedPing:
 
 
 class ViewMissedPings(PrivateView):
-    def __init__(self, cog: "AFK", user_id: int, user: discord.User | discord.Member, string_for_after_missed_pings_clear: str):
+    def __init__(self, cog: "AFK", user_id: int, user: discord.User | discord.Member,
+                 string_for_after_missed_pings_clear: str):
         super().__init__(user, timeout=120)
         self.cog = cog
         self.user_id = user_id
@@ -51,7 +52,6 @@ class ViewMissedPings(PrivateView):
 
     @discord.ui.button(label="View Missed Pings", style=discord.ButtonStyle.primary)
     async def view_missed_pings(self, interaction: discord.Interaction, button: discord.ui.Button):
-
         entries = self.cog.missed_pings_cache.get(self.user_id, [])
 
         if not entries:
@@ -100,8 +100,46 @@ class ViewMissedPings(PrivateView):
             await self.cog.clear_missed_pings(self.user_id)
 
     async def on_timeout(self) -> None:
-        await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
+        if self.message:
+            try:
+                await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
+            except (discord.NotFound, discord.HTTPException):
+                pass
         await self.cog.clear_missed_pings(self.user_id)
+        self.stop()
+
+
+class ViewNotifyOnReturn(discord.ui.View):
+    """View attached to the AFK notice allowing users to be notified when the AFK target returns."""
+
+    def __init__(self, cog: "AFK", afk_user_id: int):
+        super().__init__(timeout=259200)
+        self.cog = cog
+        self.afk_user_id = afk_user_id
+        self.message = None
+
+    @discord.ui.button(label="DM me upon their grand return", style=discord.ButtonStyle.secondary,
+                       custom_id="afk_notify_on_return")
+    async def notify_me(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id == self.afk_user_id:
+            return await interaction.response.send_message("Don't you think this is a bit too narcissistic? You cannot register to be notified about your own grand return.",
+                                                           ephemeral=True)
+
+        if self.afk_user_id not in self.cog.afk_users:
+            return await interaction.response.send_message("This user is no longer AFK.", ephemeral=True)
+
+        success = await self.cog.add_notification_request(self.afk_user_id, interaction.user.id)
+        if success:
+            await interaction.response.send_message("Got it! You will now be DMed upon their grand return.", ephemeral=True)
+        else:
+            success = await self.cog.remove_notification_request(self.afk_user_id, interaction.user.id)
+            if success:
+                await interaction.response.send_message("You will no longer be notified upon their grand return. Sad.",
+                                                        ephemeral=True)
+            else:
+                await interaction.response.send_message("sum ting wong", ephemeral=True)
+    async def on_timeout(self) -> None:
+        await self.message.edit(view=None)
         self.stop()
 
 
@@ -111,6 +149,7 @@ class AFK(commands.Cog):
         self.db_pool: Optional[asyncio.Queue[aiosqlite.Connection]] = None
         self.afk_users: Dict[int, AFKState] = {}
         self.missed_pings_cache: Dict[int, List[MissedPing]] = {}
+        self.notification_cache: Dict[int, Set[int]] = {}
 
     async def cog_load(self):
         await self.init_pools()
@@ -196,6 +235,15 @@ class AFK(commands.Cog):
                 """
             )
             await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS return_notifications (
+                    afk_user_id INTEGER NOT NULL,
+                    observer_id INTEGER NOT NULL,
+                    PRIMARY KEY (afk_user_id, observer_id)
+                )
+                """
+            )
+            await db.execute(
                 "CREATE INDEX IF NOT EXISTS idx_missed_pings_user_id ON missed_pings (user_id, timestamp)"
             )
             await db.commit()
@@ -203,6 +251,7 @@ class AFK(commands.Cog):
     async def populate_caches(self):
         self.afk_users.clear()
         self.missed_pings_cache.clear()
+        self.notification_cache.clear()
 
         now = int(discord.utils.utcnow().timestamp())
 
@@ -229,6 +278,7 @@ class AFK(commands.Cog):
 
                     if now - started_at >= AFK_MAX_SECONDS:
                         await db.execute("DELETE FROM afk_users WHERE user_id = ?", (user_id,))
+                        await db.execute("DELETE FROM return_notifications WHERE afk_user_id = ?", (user_id,))
                         continue
 
                     state = AFKState(
@@ -274,6 +324,42 @@ class AFK(commands.Cog):
                         timestamp=timestamp,
                     )
                     self.missed_pings_cache.setdefault(user_id, []).append(entry)
+
+            async with db.execute("SELECT afk_user_id, observer_id FROM return_notifications") as cursor:
+                rows = await cursor.fetchall()
+                for afk_uid, obs_id in rows:
+                    self.notification_cache.setdefault(afk_uid, set()).add(obs_id)
+
+    async def add_notification_request(self, afk_user_id: int, observer_id: int) -> bool:
+        observers = self.notification_cache.setdefault(afk_user_id, set())
+        if observer_id in observers:
+            return False
+
+        observers.add(observer_id)
+        async with self.acquire_db() as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO return_notifications (afk_user_id, observer_id) VALUES (?, ?)",
+                (afk_user_id, observer_id)
+            )
+            await db.commit()
+        return True
+
+    async def remove_notification_request(self, afk_user_id: int, observer_id: int) -> bool:
+        observers = self.notification_cache.get(afk_user_id)
+        if not observers or observer_id not in observers:
+            return False
+
+        observers.discard(observer_id)
+        if not observers:
+            self.notification_cache.pop(afk_user_id, None)
+
+        async with self.acquire_db() as db:
+            await db.execute(
+                "DELETE FROM return_notifications WHERE afk_user_id = ? AND observer_id = ?",
+                (afk_user_id, observer_id)
+            )
+            await db.commit()
+        return True
 
     async def set_afk(
             self,
@@ -353,8 +439,22 @@ class AFK(commands.Cog):
                     except (discord.Forbidden, discord.HTTPException):
                         pass
 
+        observers = self.notification_cache.pop(user_id, set())
+        if observers:
+            afk_user = self.bot.get_user(user_id) or await self.bot.fetch_user(user_id)
+            afk_name = afk_user.mention if afk_user else f"User `{user_id}`"
+
+            for obs_id in observers:
+                obs_user = self.bot.get_user(obs_id) or await self.bot.fetch_user(obs_id)
+                if obs_user:
+                    try:
+                        await obs_user.send(f"{afk_name} has now made their grand return from being AFK! You should probably go talk to them or something.\n-# To not receive this in the future, don't click the big black button to be notified next time, duh.")
+                    except discord.Forbidden:
+                        pass
+
         async with self.acquire_db() as db:
             await db.execute("DELETE FROM afk_users WHERE user_id = ?", (user_id,))
+            await db.execute("DELETE FROM return_notifications WHERE afk_user_id = ?", (user_id,))
             await db.commit()
 
     async def clear_missed_pings(self, user_id: int):
@@ -488,11 +588,13 @@ class AFK(commands.Cog):
             if now >= state.buffer_until:
                 missed = self.missed_pings_cache.get(user_id, [])
                 content, string_for_after_missed_pings_clear = self._format_welcome_back(state, len(missed))
-                view = ViewMissedPings(self, user_id, message.author, string_for_after_missed_pings_clear) if missed and state.save_missed_pings else None
+                view = ViewMissedPings(self, user_id, message.author,
+                                       string_for_after_missed_pings_clear) if missed and state.save_missed_pings else None
 
                 try:
                     msg = await message.reply(content, view=view, mention_author=False)
-                    view.message = msg
+                    if view:
+                        view.message = msg
                 except (discord.Forbidden, discord.HTTPException):
                     pass
 
@@ -529,7 +631,9 @@ class AFK(commands.Cog):
 
             notice = self._format_afk_notice(mentioned, state)
             try:
-                await message.channel.send(notice)
+                notify_view = ViewNotifyOnReturn(self, mentioned.id)
+                msg = await message.channel.send(notice, view=notify_view)
+                notify_view.message = msg
             except (discord.Forbidden, discord.HTTPException):
                 pass
 
@@ -559,7 +663,9 @@ class AFK(commands.Cog):
                     if len(role.members) <= 3:
                         notice = self._format_afk_notice(member, state)
                         try:
-                            await message.channel.send(notice)
+                            notify_view = ViewNotifyOnReturn(self, member.id)
+                            msg = await message.channel.send(notice, view=notify_view)
+                            notify_view.message = msg
                         except (discord.Forbidden, discord.HTTPException):
                             pass
 
@@ -658,7 +764,8 @@ class AFK(commands.Cog):
     async def data_export_guild(self, guild_id: int) -> DataExportChunk:
         return DataExportChunk(feature_id="afk")
 
-    async def data_delete_user(self, user_id: int, *, guild_ids: list[int] | None, feature_id: str | None) -> DataDeleteResult:
+    async def data_delete_user(self, user_id: int, *, guild_ids: list[int] | None,
+                               feature_id: str | None) -> DataDeleteResult:
         if feature_id and feature_id != "afk":
             return DataDeleteResult(feature_id="afk")
         rows_affected = 0
@@ -667,9 +774,15 @@ class AFK(commands.Cog):
             rows_affected += cur.rowcount
             cur = await db.execute("DELETE FROM missed_pings WHERE user_id = ?", (user_id,))
             rows_affected += cur.rowcount
+            cur = await db.execute("DELETE FROM return_notifications WHERE afk_user_id = ? OR observer_id = ?",
+                                   (user_id, user_id))
+            rows_affected += cur.rowcount
             await db.commit()
         self.afk_users.pop(user_id, None)
         self.missed_pings_cache.pop(user_id, None)
+        self.notification_cache.pop(user_id, None)
+        for uid in list(self.notification_cache.keys()):
+            self.notification_cache[uid].discard(user_id)
         return DataDeleteResult(feature_id="afk", deleted=True, rows_affected=rows_affected)
 
     async def data_delete_guild(self, guild_id: int, feature_id: str | None) -> DataDeleteResult:

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,10 +1,11 @@
 import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Set
+from typing import Dict, List, Optional, Tuple, Set, Any, AsyncGenerator
 
 import aiosqlite
 import discord
+from aiosqlite import Connection
 from discord import app_commands
 from discord.ext import commands
 
@@ -177,9 +178,11 @@ class ViewMissedPings(PrivateView):
         sent = await paginator.send_initial()
 
         if sent:
-            await interaction.response.send_message(
-                f"I sent the Missed Pings to your DMs! [Click here to Jump]({paginator.message.jump_url}).", ephemeral=True)
-            await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
+            if not paginator.message is None:
+                await interaction.response.send_message(
+                    f"I sent the Missed Pings to your DMs! [Click here to Jump]({paginator.message.jump_url}).", ephemeral=True)
+            if not self.message is None:
+                await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
             await self.cog.clear_missed_pings(self.user_id)
         else:
             await interaction.response.send_message(
@@ -226,7 +229,8 @@ class ViewNotifyOnReturn(discord.ui.View):
             else:
                 await interaction.response.send_message("sum ting wong", ephemeral=True)
     async def on_timeout(self) -> None:
-        await self.message.edit(view=None)
+        if self.message:
+            await self.message.edit(view=None)
         self.stop()
 
 
@@ -253,7 +257,7 @@ class AFK(commands.Cog):
                     break
             self.db_pool = None
 
-    async def create_pooled_connection(self, path: str) -> aiosqlite.Connection:
+    async def create_pooled_connection(self, path: str) -> Connection | None:
         max_retries = 5
         for attempt in range(max_retries):
             try:
@@ -279,10 +283,11 @@ class AFK(commands.Cog):
             self.db_pool = asyncio.Queue(maxsize=pool_size)
             for _ in range(pool_size):
                 conn = await self.create_pooled_connection(AFKDB_PATH)
-                await self.db_pool.put(conn)
+                if not conn is None:
+                    await self.db_pool.put(conn)
 
     @asynccontextmanager
-    async def acquire_db(self) -> aiosqlite.Connection:
+    async def acquire_db(self) -> AsyncGenerator[Connection, Any]:
         assert self.db_pool is not None
         conn = await self.db_pool.get()
         try:
@@ -550,7 +555,7 @@ class AFK(commands.Cog):
             await db.execute("DELETE FROM missed_pings WHERE user_id = ?", (user_id,))
             await db.commit()
 
-    def _format_afk_notice(self, member: discord.Member, state: AFKState) -> str:
+    def _format_afk_notice(self, member: discord.Member | discord.User, state: AFKState) -> str:
         now = int(discord.utils.utcnow().timestamp())
         elapsed = max(0, now - state.started_at)
 
@@ -679,9 +684,12 @@ class AFK(commands.Cog):
                                        string_for_after_missed_pings_clear) if missed and state.save_missed_pings else None
 
                 try:
-                    msg = await message.reply(content, view=view, mention_author=False)
+
                     if view:
+                        msg = await message.reply(content, view=view, mention_author=False)
                         view.message = msg
+                    else:
+                        await message.reply(content, mention_author=False)
                 except (discord.Forbidden, discord.HTTPException):
                     pass
 
@@ -804,7 +812,8 @@ class AFK(commands.Cog):
             )
             await db.commit()
             mp_id = cursor.lastrowid
-
+        if mp_id is None:
+            return
         entry = MissedPing(
             id=mp_id,
             user_id=user_id,

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -42,10 +42,12 @@ class MissedPing:
 
 
 class ViewMissedPings(PrivateView):
-    def __init__(self, cog: "AFK", user_id: int, user: discord.User):
-        super().__init__(user, timeout=None)
+    def __init__(self, cog: "AFK", user_id: int, user: discord.User | discord.Member, string_for_after_missed_pings_clear: str):
+        super().__init__(user, timeout=120)
         self.cog = cog
         self.user_id = user_id
+        self.message = None
+        self.string_for_after_missed_pings_clear = string_for_after_missed_pings_clear
 
     @discord.ui.button(label="View Missed Pings", style=discord.ButtonStyle.primary)
     async def view_missed_pings(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -94,7 +96,13 @@ class ViewMissedPings(PrivateView):
         if sent:
             await interaction.response.send_message(
                 f"I sent the Missed Pings to your DMs! [Click here to Jump]({link}).", ephemeral=True)
+            await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
             await self.cog.clear_missed_pings(self.user_id)
+
+    async def on_timeout(self) -> None:
+        await self.message.edit(content=self.string_for_after_missed_pings_clear, view=None)
+        await self.cog.clear_missed_pings(self.user_id)
+        self.stop()
 
 
 class AFK(commands.Cog):
@@ -372,7 +380,7 @@ class AFK(commands.Cog):
             return f"{member.display_name} is AFK: {state.status} - {ago}"
         return f"{member.display_name} is AFK - {ago}"
 
-    def _format_welcome_back(self, state: AFKState, missed_count: int) -> str:
+    def _format_welcome_back(self, state: AFKState, missed_count: int) -> tuple[str, str]:
         now = int(discord.utils.utcnow().timestamp())
         elapsed = max(0, now - state.started_at)
 
@@ -390,10 +398,11 @@ class AFK(commands.Cog):
             else:
                 base = f"Welcome back! You were AFK for **{hours}** hours!"
 
+        string_for_after_missed_pings_clear = base
         if missed_count > 0 and state.save_missed_pings:
             base += f"\nYou have **{missed_count}** missed pings!"
 
-        return base
+        return base, string_for_after_missed_pings_clear
 
     def _is_afk_active_in_context(self, state: AFKState, guild: Optional[discord.Guild]) -> bool:
         now = int(discord.utils.utcnow().timestamp())
@@ -478,11 +487,12 @@ class AFK(commands.Cog):
 
             if now >= state.buffer_until:
                 missed = self.missed_pings_cache.get(user_id, [])
-                content = self._format_welcome_back(state, len(missed))
-                view = ViewMissedPings(self, user_id, message.author) if missed and state.save_missed_pings else None
+                content, string_for_after_missed_pings_clear = self._format_welcome_back(state, len(missed))
+                view = ViewMissedPings(self, user_id, message.author, string_for_after_missed_pings_clear) if missed and state.save_missed_pings else None
 
                 try:
-                    await message.reply(content, view=view, mention_author=False)
+                    msg = await message.reply(content, view=view, mention_author=False)
+                    view.message = msg
                 except (discord.Forbidden, discord.HTTPException):
                     pass
 
@@ -532,7 +542,7 @@ class AFK(commands.Cog):
                     if not self._is_afk_active_in_context(state, message.guild):
                         continue
 
-                    member = message.guild.get_member(uid)
+                    member = message.guild.get_member(uid) or await message.guild.fetch_member(uid)
                     if not member or role not in member.roles:
                         continue
 
@@ -560,7 +570,7 @@ class AFK(commands.Cog):
         for user_id, entries in self.missed_pings_cache.items():
             for entry in entries:
                 if entry.message_id == message_id:
-                    entry.content = "*[This message was deleted]*"
+                    entry.content = "*This message was deleted*"
 
         async with self.acquire_db() as db:
             await db.execute(

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -119,46 +119,22 @@ class AutoPublish(commands.Cog):
         finally:
             await self.pool.release(conn)
 
-    async def channel_autocomplete(self, interaction: discord.Interaction, current: str) -> List[
-        app_commands.Choice[str]]:
-        if not interaction.guild:
-            return []
-
-        choices = []
-        for channel_id in self.cache:
-            channel = interaction.guild.get_channel(channel_id) or await interaction.guild.fetch_channel(channel_id)
-            if channel and current.lower() in channel.name.lower():
-                choices.append(app_commands.Choice(name=channel.name, value=str(channel_id)))
-
-            if len(choices) >= 25:
-                break
-
-        return choices
-
     @autopublish_group.command(name="disable", description="Disable auto-publishing for a channel.")
-    @app_commands.autocomplete(channel_id=channel_autocomplete)
+    @app_commands.describe(channel="The announcement channel to disable auto-publish for.")
     @app_commands.checks.has_permissions(manage_channels=True)
-    async def ap_disable(self, interaction: discord.Interaction, channel_id: str):
-        try:
-            cid = int(channel_id)
-        except ValueError:
-            return await interaction.response.send_message("Invalid channel ID selection.", ephemeral=True)
-
-        if cid not in self.cache:
-            return await interaction.response.send_message("Auto-publish is not enabled for this channel!",
+    async def ap_disable(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        if channel.id not in self.cache:
+            return await interaction.response.send_message(f"Auto-publish is not enabled for {channel.mention}!",
                                                            ephemeral=True)
 
         conn = await self.pool.acquire()
         try:
-            await conn.execute("DELETE FROM autopublish_channels WHERE channel_id = ?", (cid,))
+            await conn.execute("DELETE FROM autopublish_channels WHERE channel_id = ?", (channel.id,))
             await conn.commit()
 
-            self.cache.discard(cid)
+            self.cache.discard(channel.id)
 
-            channel = interaction.guild.get_channel(cid) or await interaction.guild.fetch_channel(cid)
-            name = channel.mention if channel else f"ID: {cid}"
-
-            await interaction.response.send_message(f"Auto-publish disabled for {name}.", ephemeral=True)
+            await interaction.response.send_message(f"Auto-publish disabled for {channel.mention}.", ephemeral=True)
         except Exception as e:
             print(f"DB Error on disable: {e}")
             await interaction.response.send_message("A database error occurred.", ephemeral=True)

--- a/cogs/autopublish.py
+++ b/cogs/autopublish.py
@@ -9,7 +9,7 @@ from typing import List, Set
 from config import APDB_PATH
 
 from beacon import beacon_commands
-
+import collections
 
 class ConnectionPool:
 
@@ -46,6 +46,9 @@ class AutoPublish(commands.Cog):
         self.bot = bot
         self.pool = ConnectionPool(APDB_PATH, max_connections=5)
         self.cache: Set[int] = set()
+        self.publish_deque = collections.deque(maxlen=5)
+        self.new_item_event = asyncio.Event()
+        self.queue_task = None
 
     async def cog_load(self):
         await self.pool.init_pool()
@@ -65,9 +68,37 @@ class AutoPublish(commands.Cog):
                 self.cache = {row[0] for row in rows}
         finally:
             await self.pool.release(conn)
+        self.queue_task = asyncio.create_task(self.publish_worker())
 
     async def cog_unload(self):
+        if self.queue_task:
+            self.queue_task.cancel()
         await self.pool.close()
+
+    async def publish_worker(self):
+        DELAY_BETWEEN_PUBLISHES = 365
+
+        while True:
+            if not self.publish_deque:
+                self.new_item_event.clear()
+                await self.new_item_event.wait()
+
+            message = self.publish_deque.popleft()
+
+            try:
+                await message.publish()
+                await asyncio.sleep(DELAY_BETWEEN_PUBLISHES)
+            except discord.HTTPException as e:
+                if e.status == 429:
+                    await asyncio.sleep(3600)
+                else:
+                    from utils.discord_health import is_access_error, report_access_failure
+                    if is_access_error(e) and message.guild:
+                        await report_access_failure(
+                            self.bot, message.guild.id, "autopublish", str(message.channel.id)
+                        )
+            except Exception:
+                pass
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -78,14 +109,9 @@ class AutoPublish(commands.Cog):
             return
 
         if message.channel.type == discord.ChannelType.news:
-            try:
-                await message.publish()
-            except (discord.Forbidden, discord.NotFound, discord.HTTPException) as e:
-                from utils.discord_health import is_access_error, report_access_failure
-                if is_access_error(e) and message.guild:
-                    await report_access_failure(
-                        self.bot, message.guild.id, "autopublish", str(message.channel.id)
-                    )
+            self.publish_deque.append(message)
+
+            self.new_item_event.set()
 
     autopublish_group = beacon_commands.Group(name="autopublish",
                                            description="Manage auto-publishing for announcement channels.")

--- a/cogs/autoreact.py
+++ b/cogs/autoreact.py
@@ -49,7 +49,8 @@ class CreatePanelModal(discord.ui.Modal):
 
         parsed = self.cog.parse_emoji_input(emoji_raw)
         if not (0 < len(parsed) <= 3):
-            return await interaction.response.send_message("Provide 1-3 valid emojis.", ephemeral=True)
+            await interaction.response.send_message("Provide 1-3 valid emojis.", ephemeral=True)
+            return
 
         guild_panels = [p for (g, pid), p in self.cog.panel_cache.items() if g == self.guild_id]
         existing_ids = {p['panel_id'] for p in guild_panels}
@@ -100,7 +101,8 @@ class EditPanelDetailsModal(discord.ui.Modal):
         parsed = self.cog.parse_emoji_input(self.emoji_input.value)
 
         if not (0 < len(parsed) <= 3):
-            return await interaction.response.send_message("Provide 1-3 valid emojis.", ephemeral=True)
+            await interaction.response.send_message("Provide 1-3 valid emojis.", ephemeral=True)
+            return
 
         serialized = self.cog.serialize_emojis(parsed)
 
@@ -189,14 +191,16 @@ class AutoreactDashboard(PrivateLayoutView):
 
     async def create_callback(self, interaction: discord.Interaction):
         if not await self.cog.bot.get_cog('TopGGVoter').check_vote_access(interaction.user.id):
-            return await interaction.response.send_message("Vote required to use this feature.", ephemeral=True)
-
-        view = CreateChannelSelect(self.user, self.cog, interaction.guild.id)
-        await interaction.response.send_message(view=view, ephemeral=True)
+            await interaction.response.send_message("Vote required to use this feature.", ephemeral=True)
+            return
+        if interaction.guild is not None:
+            view = CreateChannelSelect(self.user, self.cog, interaction.guild.id)
+            await interaction.response.send_message(view=view, ephemeral=True)
 
     async def manage_callback(self, interaction: discord.Interaction):
-        view = ManagePage(self.user, self.cog, interaction.guild.id)
-        await interaction.response.edit_message(content=None, embed=None, view=view)
+        if interaction.guild is not None:
+            view = ManagePage(self.user, self.cog, interaction.guild.id)
+            await interaction.response.edit_message(content=None, embed=None, view=view)
 
 
 class ManagePage(PrivateLayoutView):
@@ -250,7 +254,8 @@ class ManagePage(PrivateLayoutView):
             left_btn.callback = self.prev_page
 
             go_btn = discord.ui.Button(label="Go To Page", style=discord.ButtonStyle.secondary, disabled=(total_pages <= 1))
-            go_btn.callback = lambda i: i.response.send_modal(GoToPageModal(self, total_pages))
+            # pyrefly: ignore [no-matching-overload]
+            go_btn.callback = lambda interaction: interaction.response.send_modal(GoToPageModal(self, total_pages))
 
             right_btn = discord.ui.Button(emoji="▶", style=discord.ButtonStyle.primary, disabled=(self.page == total_pages))
             right_btn.callback = self.next_page
@@ -400,7 +405,7 @@ class EditPage(PrivateLayoutView):
     async def delete_panel(self, interaction: discord.Interaction):
         view = DestructiveConfirmationView(self.user, self.panel['name'], self.cog, self.panel['guild_id'],
                                            self.panel['panel_id'])
-        await interaction.response.send_message(content=None, embed=None, view=view)
+        await interaction.response.send_message(view=view)
 
     async def toggle_whitelist(self, interaction: discord.Interaction):
         if self.panel['member_whitelist']:
@@ -473,7 +478,7 @@ class EditChannelSelect(PrivateLayoutView):
         self.cog = cog
         self.guild_id = guild_id
         self.is_rebind = is_rebind
-        self.panel_data = panel_data
+        self.panel_data = panel_data if panel_data is not None else {}
         self.build_layout()
 
     def build_layout(self):
@@ -495,7 +500,6 @@ class EditChannelSelect(PrivateLayoutView):
 
     async def select_callback(self, interaction: discord.Interaction):
         new_channel_id = self.select.values[0].id
-
         async with self.cog.acquire_db() as db:
             await db.execute(
                 "UPDATE autoreact_panels SET channel_id = ? WHERE guild_id = ? AND panel_id = ?",
@@ -515,7 +519,7 @@ class MemberSelect(PrivateLayoutView):
         self.cog = cog
         self.guild_id = guild_id
         self.is_rebind = is_rebind
-        self.panel_data = panel_data
+        self.panel_data = panel_data if panel_data is not None else {}
         self.build_layout()
 
     def build_layout(self):
@@ -611,21 +615,11 @@ class DestructiveConfirmationView(PrivateLayoutView):
         self.value = False
         await self.update_view(interaction, "Action Canceled", discord.Color(0xdf5046))
 
-        view = EditPage(self.user, self.cog, self.cog.panel_cache[(self.guild_id, self.panel_id)])
-        await interaction.followup.send("Returned to edit menu.", ephemeral=True, view=view)
-
     async def confirm_callback(self, interaction: discord.Interaction):
         self.value = True
         await self.update_view(interaction, "Action Confirmed", discord.Color.green())
         await self.cog.delete_panel(self.guild_id, self.panel_id)
 
-        view = AutoreactDashboard(self.user, self.cog)
-        await interaction.followup.send("Returned to dashboard.", ephemeral=True, view=view)
-
-    async def on_timeout(self, interaction: discord.Interaction):
-        if self.value is None:
-            self.value = False
-            await self.update_view(interaction, "Timed Out", discord.Color(0xdf5046))
 
 
 class AutoReact(commands.Cog):
@@ -680,6 +674,8 @@ class AutoReact(commands.Cog):
 
     @asynccontextmanager
     async def acquire_db(self):
+        if self.db_pool is None:
+            return
         conn = await self.db_pool.get()
         try:
             yield conn

--- a/cogs/autoresponse.py
+++ b/cogs/autoresponse.py
@@ -747,8 +747,10 @@ class FinalStep(PrivateLayoutView):
 
         async def save_and_start(interaction: discord.Interaction):
             record = await self.cog.create_autoresponse_from_draft(self.guild_id, interaction.user.id, self.draft)
-            await interaction.response.send_message(
-                content=f"Autoresponse for trigger `{record.trigger}` saved and enabled successfully!", view=None, ephemeral=True
+            await interaction.response.defer()
+            await interaction.delete_original_response()
+            await interaction.followup.send(
+                content=f"Autoresponse for trigger `{record.trigger}` saved and enabled successfully!", ephemeral=True
             )
 
         case_btn.callback = toggle_case

--- a/cogs/autoresponse.py
+++ b/cogs/autoresponse.py
@@ -275,7 +275,7 @@ class ManageAutoresponsePage(PrivateLayoutView):
 
             nav_row = discord.ui.ActionRow()
             left_btn = discord.ui.Button(emoji="◀️", style=discord.ButtonStyle.primary, disabled=(self.page <= 1))
-            goto_btn = discord.ui.Button(label=f"Page {self.page}", style=discord.ButtonStyle.secondary)
+            goto_btn = discord.ui.Button(label=f"Go To Page", style=discord.ButtonStyle.secondary)
             right_btn = discord.ui.Button(emoji="▶️", style=discord.ButtonStyle.primary, disabled=(self.page >= total_pages))
 
             async def prev_page(interaction: discord.Interaction):

--- a/cogs/data.py
+++ b/cogs/data.py
@@ -795,9 +795,9 @@ class Data(commands.Cog):
 
     @beacon_commands.command(name="di", description=".", permissions_preset="bot_owner")
     async def di_cmd(self, interaction: discord.Interaction):
-        await interaction.response.defer()
+        await interaction.response.defer(ephemeral=True)
         await self.refresh_insights_cache()
-        await interaction.edit_original_response(view=InsightsDashboard(self, interaction.user), ephemeral=True)
+        await interaction.edit_original_response(view=InsightsDashboard(self, interaction.user))
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/dblc.py
+++ b/cogs/dblc.py
@@ -2,7 +2,7 @@ import importlib
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
-from beacon import mod_check, ViewPaginator
+from beacon import ViewPaginator
 import VERSION
 import psutil
 import os
@@ -52,7 +52,6 @@ class Dblc(commands.Cog):
         await interaction.response.send_message(embed=embed)
 
     @beacon_commands.command(name="purge", description="Delete recent messages.", permissions_preset="support")
-    @app_commands.check(mod_check)
     @app_commands.describe(number="Number of messages to delete (max 100)")
     async def purge(self, interaction: discord.Interaction, number: int):
         number = max(1, min(number, 100))

--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -716,14 +716,16 @@ class TemplateHomepage(PrivateLayoutView):
         self.add_item(container)
 
     async def browse_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         templates = await self.cog.fetch_templates(guild_id=interaction.guild.id, mode="browse")
         view = BrowsePage(self.cog, self.user, templates, interaction.guild.id, is_th=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def mystuff_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         templates = await self.cog.fetch_templates(user_id=self.user.id, mode="mine")
         view = MystuffPage(self.cog, self.user, templates)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
 
 class MystuffPage(PrivateLayoutView):
@@ -1202,14 +1204,16 @@ class CreatewithtemplatePage(PrivateLayoutView):
             SearchModal("id_direct", self))
 
     async def browse_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         templates = await self.cog.fetch_templates(guild_id=interaction.guild.id, mode="browse")
         view = BrowsePage(self.cog, self.user, templates, interaction.guild.id)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def my_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         templates = await self.cog.fetch_templates(user_id=self.user.id, mode="mine")
         view = MystuffUse(self.cog, self.user, templates)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def back_callback(self, interaction: discord.Interaction):
         view = CreateChoose(self.cog, self.user)

--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -1711,6 +1711,49 @@ class Giveaways(commands.Cog):
 
             await db.commit()
 
+            await self._run_migrations(db)
+
+    async def _run_migrations(self, db: aiosqlite.Connection):
+        """
+        Automatically fixes data type mismatches in the database.
+        """
+        async with db.execute("SELECT giveaway_id, guild_id, winners_count FROM giveaways") as cursor:
+            async for row in cursor:
+                g_id, guild_id, w_count = row
+
+
+                if isinstance(w_count, str):
+                    try:
+                        new_count = int(w_count)
+                    except ValueError:
+                        # If it's "123,456" (the role ID bug), we can't know the real count.
+                        # Default to 1 to prevent the bot from crashing.
+                        new_count = 1
+
+                    await db.execute(
+                        "UPDATE giveaways SET winners_count = ? WHERE giveaway_id = ? AND guild_id = ?",
+                        (new_count, g_id, guild_id)
+                    )
+                    print(
+                        f"[Migration] Fixed winners_count for giveaway {g_id} in guild {guild_id}: '{w_count}' -> {new_count}")
+
+        async with db.execute("SELECT template_id, winners FROM templates") as cursor:
+            async for row in cursor:
+                t_id, w_count = row
+                if isinstance(w_count, str):
+                    try:
+                        new_count = int(w_count)
+                    except ValueError:
+                        new_count = 1
+
+                    await db.execute(
+                        "UPDATE templates SET winners = ? WHERE template_id = ?",
+                        (new_count, t_id)
+                    )
+                    print(f"[Migration] Fixed template winners for {t_id}: '{w_count}' -> {new_count}")
+
+        await db.commit()
+
     async def populate_caches(self):
         self.giveaway_cache.clear()
         self.participant_cache.clear()
@@ -1964,14 +2007,14 @@ class Giveaways(commands.Cog):
             "channel_id": draft.channel_id,
             "message_id": message_id,
             "prize": draft.prize,
-            "winners_count": winner_roles,
+            "winners_count": draft.winners,
             "end_time": end_time,
             "host_id": draft.host_id,
             "required_roles": req_roles,
             "req_behaviour": draft.required_behaviour,
             "blacklisted_roles": black_roles,
             "extra_entry_roles": extra_roles,
-            "winner_role_id": draft.winner_role,
+            "winner_role_id": winner_roles,
             "image_url": draft.image,
             "thumbnail_url": draft.thumbnail,
             "color": draft.color,
@@ -2027,7 +2070,7 @@ class Giveaways(commands.Cog):
             "creator_id": interaction.user.id,
             "creation_guild_id": interaction.guild.id,
             "prize": draft.prize,
-            "winners": winner_roles,
+            "winners": draft.winners,
             "duration": draft.duration,
             "channel_id": draft.channel_id,
             "host_id": draft.host_id,
@@ -2035,7 +2078,7 @@ class Giveaways(commands.Cog):
             "req_behaviour": draft.required_behaviour,
             "blacklisted_roles": black_roles,
             "extra_entries": extra_roles,
-            "winner_role_id": draft.winner_role,
+            "winner_role_id": winner_roles,
             "image": draft.image,
             "thumbnail": draft.thumbnail,
             "color": draft.color

--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -1638,6 +1638,7 @@ class Giveaways(commands.Cog):
 
     async def init_db(self):
         async with self.acquire_db() as db:
+            await self._migrate_winner_role_to_text(db)
             await db.execute('''
                 CREATE TABLE IF NOT EXISTS giveaways (
                     guild_id INTEGER,
@@ -1652,7 +1653,7 @@ class Giveaways(commands.Cog):
                     req_behaviour INTEGER,
                     blacklisted_roles TEXT,
                     extra_entry_roles TEXT,
-                    winner_role_id INTEGER,
+                    winner_role_id TEXT,
                     image_url TEXT,
                     thumbnail_url TEXT,
                     color TEXT,
@@ -1753,6 +1754,65 @@ class Giveaways(commands.Cog):
                     print(f"[Migration] Fixed template winners for {t_id}: '{w_count}' -> {new_count}")
 
         await db.commit()
+
+    async def _migrate_winner_role_to_text(self, db: aiosqlite.Connection):
+        """
+        Migrates the 'winner_role_id' column from INTEGER to TEXT to support
+        multiple role IDs.
+        """
+        async with db.execute("PRAGMA table_info(giveaways)") as cursor:
+            columns = await cursor.fetchall()
+            # column[1] is name, column[2] is type
+            winner_role_col = next((c for c in columns if c[1] == "winner_role_id"), None)
+
+            if not winner_role_col or winner_role_col[2].upper() != "TEXT":
+                return
+
+        self.bot.logger.info("[Migration] Detected winner_role_id is not TEXT. Starting migration...")
+
+        await db.execute('''
+            CREATE TABLE giveaways_new (
+                guild_id INTEGER,
+                giveaway_id INTEGER,
+                channel_id INTEGER,
+                message_id INTEGER,
+                prize TEXT,
+                winners_count INTEGER,
+                end_time INTEGER,
+                host_id INTEGER,
+                required_roles TEXT,
+                req_behaviour INTEGER,
+                blacklisted_roles TEXT,
+                extra_entry_roles TEXT,
+                winner_role_id TEXT,  -- This is now TEXT
+                image_url TEXT,
+                thumbnail_url TEXT,
+                color TEXT,
+                ended INTEGER DEFAULT 0,
+                PRIMARY KEY (guild_id, giveaway_id)
+            )
+        ''')
+
+        await db.execute('''
+            INSERT INTO giveaways_new (
+                guild_id, giveaway_id, channel_id, message_id, prize, 
+                winners_count, end_time, host_id, required_roles, 
+                req_behaviour, blacklisted_roles, extra_entry_roles, 
+                winner_role_id, image_url, thumbnail_url, color, ended
+            )
+            SELECT 
+                guild_id, giveaway_id, channel_id, message_id, prize, 
+                winners_count, end_time, host_id, required_roles, 
+                req_behaviour, blacklisted_roles, extra_entry_roles, 
+                winner_role_id, image_url, thumbnail_url, color, ended
+            FROM giveaways
+        ''')
+
+        await db.execute("DROP TABLE giveaways")
+        await db.execute("ALTER TABLE giveaways_new RENAME TO giveaways")
+
+        await db.commit()
+        print("[Migration] winner_role_id successfully migrated to TEXT.")
 
     async def populate_caches(self):
         self.giveaway_cache.clear()

--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -1298,7 +1298,7 @@ class MystuffUse(PrivateLayoutView):
         await interaction.response.send_modal(GoToPageModal(self, self.total_pages))
 
     async def back_callback(self, interaction: discord.Interaction):
-        view = CreateChoose(self.cog, self.user)
+        view = CreatewithtemplatePage(self.cog, self.user)
         await interaction.response.edit_message(view=view)
 
 

--- a/cogs/haiku.py
+++ b/cogs/haiku.py
@@ -115,7 +115,7 @@ class HaikuDetector(commands.Cog):
                              CREATE TABLE IF NOT EXISTS haiku_settings
                              (
                                  guild_id INTEGER PRIMARY KEY,
-                                 is_enabled INTEGER DEFAULT 0
+                                 is_disabled INTEGER DEFAULT 0
                              )
                              ''')
             await db.commit()
@@ -132,7 +132,7 @@ class HaikuDetector(commands.Cog):
 
     async def populate_caches(self):
         async with self.acquire_hd_db() as db:
-            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_enabled = 0") as cursor:
+            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_disabled = 1") as cursor:
                 rows = await cursor.fetchall()
                 self.disabled_guilds = {row[0] for row in rows}
 
@@ -410,7 +410,7 @@ class HaikuDetector(commands.Cog):
 
         async with self.acquire_hd_db() as db:
             await db.execute(
-                "INSERT OR REPLACE INTO haiku_settings (guild_id, is_enabled) VALUES (?, 1)",
+                "INSERT OR REPLACE INTO haiku_settings (guild_id, is_disabled) VALUES (?, 0)",
                 (interaction.guild.id,)
             )
             await db.commit()
@@ -446,7 +446,7 @@ class HaikuDetector(commands.Cog):
             return
 
         async with self.acquire_hd_db() as db:
-            await db.execute("UPDATE haiku_settings SET is_enabled = 0 WHERE guild_id = ?", (interaction.guild.id,))
+            await db.execute("UPDATE haiku_settings SET is_disabled = 1 WHERE guild_id = ?", (interaction.guild.id,))
             await db.commit()
         if not interaction.guild.id in self.disabled_guilds:
             self.disabled_guilds.add(interaction.guild.id)

--- a/cogs/haiku.py
+++ b/cogs/haiku.py
@@ -38,7 +38,7 @@ class HaikuDetector(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.haiku_word_cache: Dict[str, int] = {}
-        self.disabled_guilds: Set[int] = set()
+        self.enabled_guilds: Set[int] = set()
 
         self.hd_pool: Optional[asyncio.Queue[aiosqlite.Connection]] = None
         self.hwd_pool: Optional[asyncio.Queue[aiosqlite.Connection]] = None
@@ -132,9 +132,9 @@ class HaikuDetector(commands.Cog):
 
     async def populate_caches(self):
         async with self.acquire_hd_db() as db:
-            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_enabled = 0") as cursor:
+            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_enabled = 1") as cursor:
                 rows = await cursor.fetchall()
-                self.disabled_guilds = {row[0] for row in rows}
+                self.enabled_guilds = {row[0] for row in rows}
 
         async with self.acquire_hwd_db() as db:
             async with db.execute("SELECT word, syllables FROM haiku_words") as cursor:
@@ -341,7 +341,7 @@ class HaikuDetector(commands.Cog):
         if message.guild is None or message.author.bot:
             return
 
-        if message.guild.id in self.disabled_guilds:
+        if message.guild.id not in self.enabled_guilds:
             return
 
         if message.id in self._recent_processed_messages:
@@ -388,7 +388,7 @@ class HaikuDetector(commands.Cog):
         async with self.acquire_hd_db() as db:
             cur = await db.execute("DELETE FROM haiku_settings WHERE guild_id = ?", (guild_id,))
             await db.commit()
-        self.disabled_guilds.add(guild_id)
+        self.enabled_guilds.add(guild_id)
         return DataDeleteResult(feature_id="haiku", deleted=True, rows_affected=cur.rowcount)
 
     async def data_monitor_guild(self, guild: discord.Guild) -> DataMonitorResult:
@@ -408,14 +408,23 @@ class HaikuDetector(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
+        if interaction.guild.id in self.enabled_guilds:
+            embed = discord.Embed(
+                title="Haiku Detection Already Active",
+                description="Haiku detection is already currently enabled in this server.",
+                color=discord.Color.red()
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+
         async with self.acquire_hd_db() as db:
             await db.execute(
                 "INSERT OR REPLACE INTO haiku_settings (guild_id, is_enabled) VALUES (?, 1)",
                 (interaction.guild.id,)
             )
             await db.commit()
-        if interaction.guild.id in self.disabled_guilds:
-            self.disabled_guilds.discard(interaction.guild.id)
+        if not interaction.guild.id in self.enabled_guilds:
+            self.enabled_guilds.add(interaction.guild.id)
 
         embed = discord.Embed(
             title="Haiku Detection Enabled",
@@ -427,16 +436,8 @@ class HaikuDetector(commands.Cog):
 
     @detection_group.command(name="disable", description="Disable haiku detection for the server")
     async def disable_haiku_detection(self, interaction: discord.Interaction):
-        if not await self.bot.get_cog('TopGGVoter').check_vote_access(interaction.user.id):
-            embed = discord.Embed(
-                title="Vote to Use This Feature!",
-                description=f"This command requires voting! To access this feature, please vote for Dopamine here: [top.gg](https://top.gg/bot/{self.bot.user.id})",
-                color=0xffaa00
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
 
-        if interaction.guild.id not in self.disabled_guilds:
+        if interaction.guild.id not in self.enabled_guilds:
             embed = discord.Embed(
                 title="Haiku Detection Not Active",
                 description="Haiku detection is not currently enabled in this server.",
@@ -448,8 +449,8 @@ class HaikuDetector(commands.Cog):
         async with self.acquire_hd_db() as db:
             await db.execute("UPDATE haiku_settings SET is_enabled = 0 WHERE guild_id = ?", (interaction.guild.id,))
             await db.commit()
-        if not interaction.guild.id in self.disabled_guilds:
-            self.disabled_guilds.add(interaction.guild.id)
+        if interaction.guild.id in self.enabled_guilds:
+            self.enabled_guilds.discard(interaction.guild.id)
 
         embed = discord.Embed(
             title="Haiku Detection Disabled",

--- a/cogs/haiku.py
+++ b/cogs/haiku.py
@@ -115,7 +115,7 @@ class HaikuDetector(commands.Cog):
                              CREATE TABLE IF NOT EXISTS haiku_settings
                              (
                                  guild_id INTEGER PRIMARY KEY,
-                                 is_disabled INTEGER DEFAULT 0
+                                 is_enabled INTEGER DEFAULT 0
                              )
                              ''')
             await db.commit()
@@ -132,7 +132,7 @@ class HaikuDetector(commands.Cog):
 
     async def populate_caches(self):
         async with self.acquire_hd_db() as db:
-            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_disabled = 1") as cursor:
+            async with db.execute("SELECT guild_id FROM haiku_settings WHERE is_enabled = 0") as cursor:
                 rows = await cursor.fetchall()
                 self.disabled_guilds = {row[0] for row in rows}
 
@@ -410,7 +410,7 @@ class HaikuDetector(commands.Cog):
 
         async with self.acquire_hd_db() as db:
             await db.execute(
-                "INSERT OR REPLACE INTO haiku_settings (guild_id, is_disabled) VALUES (?, 0)",
+                "INSERT OR REPLACE INTO haiku_settings (guild_id, is_enabled) VALUES (?, 1)",
                 (interaction.guild.id,)
             )
             await db.commit()
@@ -446,7 +446,7 @@ class HaikuDetector(commands.Cog):
             return
 
         async with self.acquire_hd_db() as db:
-            await db.execute("UPDATE haiku_settings SET is_disabled = 1 WHERE guild_id = ?", (interaction.guild.id,))
+            await db.execute("UPDATE haiku_settings SET is_enabled = 0 WHERE guild_id = ?", (interaction.guild.id,))
             await db.commit()
         if not interaction.guild.id in self.disabled_guilds:
             self.disabled_guilds.add(interaction.guild.id)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2622,7 +2622,7 @@ class Points(commands.Cog):
             undo_view.message = await interaction.followup.send(embed=embed, view=undo_view)
 
     @beacon_commands.command(name="pardon", description="Remove points/warnings from a user.", permissions_preset="moderator")
-    async def pardon(self, interaction: discord.Interaction, member: discord.Member, amount: int,
+    async def pardon(self, interaction: discord.Interaction, member: discord.User, amount: int,
                      reason: Optional[str] = None):
         await self.guild_setup(interaction)
         data = await self.get_user_data(interaction.guild.id, member.id)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2725,6 +2725,7 @@ class Points(commands.Cog):
 
     @case_group.command(name="history", description="View all past warnings/points for a user.")
     async def case_history(self, interaction: discord.Interaction, user: discord.User):
+        await interaction.response.defer()
         await self.guild_setup(interaction)
         settings = self.settings_cache.get(interaction.guild.id, {})
         is_simple = settings.get("simple_mode", 0) == 1
@@ -2739,7 +2740,7 @@ class Points(commands.Cog):
             view = PrivateLayoutView(interaction.user, timeout=None)
             view.clear_items()
             view.add_item(container)
-            return await interaction.response.send_message(view=view)
+            return await interaction.edit_original_response(view=view)
 
         view = CaseUserHistoryPage(
             interaction.user, self, interaction.guild, user.id, cases, term
@@ -2766,6 +2767,7 @@ class Points(commands.Cog):
 
     @case_group.command(name="all", description="Browse all members with active warnings/points.")
     async def case_all(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         await self.guild_setup(interaction)
         settings = self.settings_cache.get(interaction.guild.id, {})
         is_simple = settings.get("simple_mode", 0) == 1
@@ -2773,7 +2775,7 @@ class Points(commands.Cog):
 
         view = AllActiveInfractionsPage(interaction.user, self, interaction.guild, term)
         await view.initialize()
-        await interaction.response.send_message(view=view)
+        await interaction.edit_original_response(view=view)
         view.message = await interaction.original_response()
 
     @case_group.command(name="delete", description="Delete a case and adjust the user's warnings/points.")

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1564,9 +1564,13 @@ class AllActiveInfractionsPage(PrivateLayoutView):
         control_row.add_item(clear_btn)
         container.add_item(control_row)
 
+        settings = self.cog.settings_cache.get(self.guild.id, {})
+        is_simple = settings.get("simple_mode", 0) == 1
+        term = "Warnings" if is_simple else "Points"
+
         sort_options = [
-            discord.SelectOption(label="Most Points", value=self.SORT_MOST),
-            discord.SelectOption(label="Least Points", value=self.SORT_LEAST),
+            discord.SelectOption(label=f"Most {term}", value=self.SORT_MOST),
+            discord.SelectOption(label="Least {term}", value=self.SORT_LEAST),
             discord.SelectOption(label="Most Recent Punishment", value=self.SORT_RECENT),
             discord.SelectOption(label="Oldest Punishment", value=self.SORT_OLDEST),
             discord.SelectOption(label="Alphabetical (A–Z)", value=self.SORT_ALPHA),
@@ -1643,6 +1647,203 @@ class AllActiveInfractionsPage(PrivateLayoutView):
         self.build_layout()
         await interaction.response.edit_message(view=self)
 
+
+class AllCasesPage(PrivateLayoutView):
+    SORT_NEWEST = "newest"
+    SORT_OLDEST = "oldest"
+    SORT_HIGHEST = "highest"
+    SORT_LOWEST = "lowest"
+    SORT_CASE_ASC = "case_asc"
+    SORT_CASE_DESC = "case_desc"
+
+    def __init__(self, user, cog, guild: discord.Guild, term: str, page: int = 1,
+                 current_sort: str = SORT_NEWEST, search_query: str = None,
+                 container_header: str = None):
+        super().__init__(user, timeout=None)
+        self.cog = cog
+        self.guild = guild
+        self.guild_id = guild.id
+        self.term = term
+        self.page = page
+        self.per_page = 5
+        self.current_sort = current_sort
+        self.search_query = search_query
+        self.container_header = container_header
+        self.entries: List[dict] = []
+        self.filtered_entries: List[dict] = []
+        self.total_pages = 1
+        self.message: Optional[discord.Message] = None
+        self.build_layout()
+
+    async def initialize(self):
+        await self.refresh_data()
+        self.build_layout()
+
+    async def refresh_data(self):
+        self.entries = await self.cog.get_all_infractions(self.guild_id)
+        self.apply_filter()
+        self.apply_sort()
+        self.total_pages = max(1, (len(self.filtered_entries) - 1) // self.per_page + 1) if self.filtered_entries else 1
+        self.page = min(self.page, self.total_pages)
+
+    def apply_filter(self):
+        if self.search_query:
+            q = self.search_query.lower()
+            self.filtered_entries = [
+                e for e in self.entries
+                if q in str(e["case_number"]) or q in str(e["user_id"]) or (e["reason"] and q in e["reason"].lower())
+            ]
+        else:
+            self.filtered_entries = list(self.entries)
+
+    def apply_sort(self):
+        if self.current_sort == self.SORT_NEWEST:
+            self.entries.sort(key=lambda x: x["created_at"], reverse=True)
+        elif self.current_sort == self.SORT_OLDEST:
+            self.entries.sort(key=lambda x: x["created_at"])
+        elif self.current_sort == self.SORT_HIGHEST:
+            self.entries.sort(key=lambda x: x["amount"], reverse=True)
+        elif self.current_sort == self.SORT_LOWEST:
+            self.entries.sort(key=lambda x: x["amount"])
+        elif self.current_sort == self.SORT_CASE_ASC:
+            self.entries.sort(key=lambda x: x["case_number"])
+        elif self.current_sort == self.SORT_CASE_DESC:
+            self.entries.sort(key=lambda x: x["case_number"], reverse=True)
+
+    def build_layout(self):
+        self.clear_items()
+        container = discord.ui.Container()
+
+        count_text = f"{len(self.filtered_entries)} Total Cases"
+        if not self.container_header:
+            header = f"## Case Log — {count_text}"
+        else:
+            header = f"## {self.container_header}"
+
+        container.add_item(discord.ui.TextDisplay(header))
+        container.add_item(discord.ui.TextDisplay(
+            f"Browsing all recorded infractions. Use search to find specific Case IDs or User IDs."))
+        container.add_item(discord.ui.Separator())
+
+        start = (self.page - 1) * self.per_page
+        current = self.filtered_entries[start:start + self.per_page]
+
+        if not current:
+            container.add_item(discord.ui.TextDisplay("*No cases found matching your criteria.*"))
+        else:
+            for idx, case in enumerate(current, start + 1):
+                user_mention = f"<@{case['user_id']}>"
+
+                last_p = f"<t:{case['created_at']}:R>"
+                title = f"### Case #{case['case_number']} • +{case['amount']} {self.term}(s)"
+                desc = (
+                    f"**User:** {user_mention} (`{case['user_id']}`)\n"
+                    f"**Moderator:** <@{case['moderator_id']}>\n"
+                    f"**Date:** {last_p}\n"
+                    f"**Reason:** {case['reason'] or 'No reason provided.'}"
+                )
+
+                view_btn = discord.ui.Button(label="View Details", style=discord.ButtonStyle.primary)
+                view_btn.callback = self.create_details_callback(case)
+                container.add_item(discord.ui.Section(discord.ui.TextDisplay(f"{title}\n{desc}"), accessory=view_btn))
+
+        container.add_item(discord.ui.TextDisplay(f"-# Page {self.page} of {self.total_pages}"))
+        container.add_item(discord.ui.Separator())
+
+        nav_row = discord.ui.ActionRow()
+        left_btn = discord.ui.Button(emoji="◀️", style=discord.ButtonStyle.primary, disabled=(self.page <= 1))
+        left_btn.callback = self.prev_page
+        go_btn = discord.ui.Button(label="Go To Page", style=discord.ButtonStyle.secondary,
+                                   disabled=(self.total_pages <= 1))
+        go_btn.callback = self.go_to_page_callback
+        right_btn = discord.ui.Button(emoji="▶️", style=discord.ButtonStyle.primary,
+                                      disabled=(self.page >= self.total_pages))
+        right_btn.callback = self.next_page
+        nav_row.add_item(left_btn)
+        nav_row.add_item(go_btn)
+        nav_row.add_item(right_btn)
+        container.add_item(nav_row)
+
+        control_row = discord.ui.ActionRow()
+        search_btn = discord.ui.Button(label="Search", style=discord.ButtonStyle.primary)
+        search_btn.callback = self.search_callback
+        clear_btn = discord.ui.Button(label="Clear Search", style=discord.ButtonStyle.secondary,
+                                      disabled=(not self.search_query))
+        clear_btn.callback = self.clear_search_callback
+        control_row.add_item(search_btn)
+        control_row.add_item(clear_btn)
+        container.add_item(control_row)
+
+        settings = self.cog.settings_cache.get(self.guild.id, {})
+        is_simple = settings.get("simple_mode", 0) == 1
+        term = "Warnings" if is_simple else "Points"
+
+        sort_options = [
+            discord.SelectOption(label="Newest First", value=self.SORT_NEWEST),
+            discord.SelectOption(label="Oldest First", value=self.SORT_OLDEST),
+            discord.SelectOption(label=f"Highest {term}", value=self.SORT_HIGHEST),
+            discord.SelectOption(label=f"Lowest {term}", value=self.SORT_LOWEST),
+            discord.SelectOption(label="Case ID (Ascending)", value=self.SORT_CASE_ASC),
+            discord.SelectOption(label="Case ID (Descending)", value=self.SORT_CASE_DESC),
+        ]
+        for opt in sort_options:
+            if opt.value == self.current_sort:
+                opt.default = True
+
+        sort_dropdown = discord.ui.Select(placeholder="Sort by...", options=sort_options)
+        sort_dropdown.callback = self.sort_callback
+        container.add_item(discord.ui.ActionRow(sort_dropdown))
+
+        container.add_item(discord.ui.Separator())
+        return_btn = discord.ui.Button(label="Return to Dashboard", style=discord.ButtonStyle.secondary)
+        return_btn.callback = self.return_home
+        container.add_item(discord.ui.ActionRow(return_btn))
+
+        self.add_item(container)
+
+    def create_details_callback(self, case):
+        async def callback(interaction: discord.Interaction):
+            view = CaseDetailPage(self.user, self.cog, self.guild, case, self.term)
+            await interaction.response.edit_message(view=view)
+            view.message = self.message
+
+        return callback
+
+    async def prev_page(self, interaction: discord.Interaction):
+        self.page -= 1
+        self.build_layout()
+        await interaction.response.edit_message(view=self)
+
+    async def next_page(self, interaction: discord.Interaction):
+        self.page += 1
+        self.build_layout()
+        await interaction.response.edit_message(view=self)
+
+    async def go_to_page_callback(self, interaction: discord.Interaction):
+        await interaction.response.send_modal(GoToPageModal(self, self.total_pages))
+
+    async def search_callback(self, interaction: discord.Interaction):
+        await interaction.response.send_modal(CaseUserSearchModal(self))
+
+    async def clear_search_callback(self, interaction: discord.Interaction):
+        self.search_query = None
+        self.container_header = None
+        self.page = 1
+        await self.refresh_data()
+        self.build_layout()
+        await interaction.response.edit_message(view=self)
+
+    async def sort_callback(self, interaction: discord.Interaction):
+        self.current_sort = interaction.data["values"][0]
+        self.page = 1
+        self.apply_sort()
+        self.apply_filter()
+        self.total_pages = max(1, (len(self.filtered_entries) - 1) // self.per_page + 1) if self.filtered_entries else 1
+        self.build_layout()
+        await interaction.response.edit_message(view=self)
+
+    async def return_home(self, interaction: discord.Interaction):
+        await interaction.response.edit_message(view=ModerationDashboard(self.user, self.cog))
 
 class Points(commands.Cog):
     def __init__(self, bot):
@@ -2732,7 +2933,7 @@ class Points(commands.Cog):
         permissions_preset="moderator",
     )
 
-    @case_group.command(name="history", description="View all past warnings/points for a user.")
+    @case_group.command(name="history", description="View all past cases for a user.")
     async def case_history(self, interaction: discord.Interaction, user: discord.User):
         await interaction.response.defer()
         await self.guild_setup(interaction)
@@ -2757,7 +2958,7 @@ class Points(commands.Cog):
         await interaction.response.send_message(view=view)
         view.message = await interaction.original_response()
 
-    @case_group.command(name="view", description="View a specific case by ID.")
+    @case_group.command(name="view", description="View a specific moderation case by ID.")
     async def case_view(self, interaction: discord.Interaction, case_id: int):
         await self.guild_setup(interaction)
         case = await self.get_infraction(interaction.guild.id, case_id)
@@ -2774,7 +2975,7 @@ class Points(commands.Cog):
         await interaction.response.send_message(view=view)
         view.message = await interaction.original_response()
 
-    @case_group.command(name="all", description="Browse all members with active warnings/points.")
+    @case_group.command(name="users", description="Shows a list of all users who have a moderation case.")
     async def case_all(self, interaction: discord.Interaction):
         await interaction.response.defer()
         await self.guild_setup(interaction)
@@ -2787,7 +2988,20 @@ class Points(commands.Cog):
         await interaction.edit_original_response(view=view)
         view.message = await interaction.original_response()
 
-    @case_group.command(name="delete", description="Delete a case and adjust the user's warnings/points.")
+    @case_group.command(name="all", description="Show a list of every moderation case recorded.")
+    async def case_all_list(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+        await self.guild_setup(interaction)
+        settings = self.settings_cache.get(interaction.guild.id, {})
+        is_simple = settings.get("simple_mode", 0) == 1
+        term = "warning" if is_simple else "point"
+
+        view = AllCasesPage(interaction.user, self, interaction.guild, term)
+        await view.initialize()
+        await interaction.edit_original_response(view=view)
+        view.message = await interaction.original_response()
+
+    @case_group.command(name="delete", description="Delete a moderation case and adjust the user's warnings/points.")
     async def case_delete(self, interaction: discord.Interaction, case_id: int):
         await self.guild_setup(interaction)
         case = await self.get_infraction(interaction.guild.id, case_id)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -2041,13 +2041,22 @@ class Points(commands.Cog):
                 await log_ch.send(embed=log_embed)
 
     async def resolve_user_display(self, guild: discord.Guild, user_id: int) -> str:
-        member = guild.get_member(user_id) or await guild.fetch_member(user_id) or await self.bot.fetch_user(user_id)
+        member = guild.get_member(user_id)
         if member:
             return f"{member.mention} (`{user_id}`)"
+
+        try:
+            member = await guild.fetch_member(user_id)
+            return f"{member.mention} (`{user_id}`)"
+        except discord.NotFound:
+            pass
+        except discord.HTTPException:
+            pass
+
         try:
             user = await self.bot.fetch_user(user_id)
             return f"**{user.display_name}** (`{user_id}`)"
-        except discord.NotFound:
+        except (discord.NotFound, discord.HTTPException):
             return f"Unknown User (`{user_id}`)"
 
     async def populate_caches(self):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1592,12 +1592,13 @@ class AllActiveInfractionsPage(PrivateLayoutView):
 
     def create_cases_callback(self, user_id: int):
         async def callback(interaction: discord.Interaction):
+            await interaction.response.defer()
             self.pause_live()
             cases = await self.cog.get_user_infractions(self.guild_id, user_id)
             view = CaseUserHistoryPage(
                 self.user, self.cog, self.guild, user_id, cases, self.term, parent=self
             )
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             view.message = self.message
         return callback
 
@@ -1616,7 +1617,6 @@ class AllActiveInfractionsPage(PrivateLayoutView):
 
     async def search_callback(self, interaction: discord.Interaction):
         await interaction.response.send_modal(CaseUserSearchModal(self))
-
     async def clear_search_callback(self, interaction: discord.Interaction):
         self.search_query = None
         self.container_header = None

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1592,6 +1592,7 @@ class AllActiveInfractionsPage(PrivateLayoutView):
 
     def create_cases_callback(self, user_id: int):
         async def callback(interaction: discord.Interaction):
+            await interaction.response.defer()
             self.pause_live()
             cases = await self.cog.get_user_infractions(self.guild_id, user_id)
             view = CaseUserHistoryPage(

--- a/cogs/notes.py
+++ b/cogs/notes.py
@@ -17,7 +17,7 @@ note_group = app_commands.Group(name="note", description="Note management comman
 
 class UndoButtonView(PrivateView):
     def __init__(self, user, cog: Notes, user_id: int, action_type: str, data: dict, interaction: discord.Interaction):
-        super().__init__(user, timeout=30.0)
+        super().__init__(user, timeout=10.0)
         self.cog = cog
         self.user_id = user_id
         self.action_type = action_type
@@ -30,7 +30,7 @@ class UndoButtonView(PrivateView):
         except Exception:
             pass
 
-    @discord.ui.button(label="Undo", style=discord.ButtonStyle.danger, custom_id="undo_action")
+    @discord.ui.button(label="Undo", style=discord.ButtonStyle.secondary, custom_id="undo_action")
     async def undo_button(self, interaction: discord.Interaction, button: discord.ui.Button):
 
         button.disabled = True

--- a/cogs/notes.py
+++ b/cogs/notes.py
@@ -203,6 +203,7 @@ class Notes(commands.Cog):
             super().__init__()
             self.cog = cog
             self.old_name = old_name
+            self.old_content = old_content
 
             self.note_name = discord.ui.TextInput(
                 label="Note Name",
@@ -265,7 +266,7 @@ class Notes(commands.Cog):
                     data={"old_name": self.old_name, "new_name": new_name, "old_content": self.old_content},
                     interaction=interaction
                 )
-                await interaction.response.send_message(embed=embed, view=undo_view, Ephemeral=True)
+                await interaction.response.send_message(embed=embed, view=undo_view, ephemeral=True)
 
             except Exception as e:
                 await interaction.response.send_message(f"Error updating note: {e}", ephemeral=True)

--- a/cogs/slowmode.py
+++ b/cogs/slowmode.py
@@ -1,4 +1,5 @@
 import discord
+from discord.app_commands import Choice
 from discord.ext import commands, tasks
 from discord import app_commands
 import aiosqlite
@@ -211,12 +212,12 @@ class ScheduledSlowmode(commands.Cog):
             return f"{', '.join(parts[:-1])} and {parts[-1]}"
 
 
-    async def timezone_autocomplete(self, interaction: discord.Interaction, current: str) -> List[
-        app_commands.Choice[str]]:
+    async def timezone_autocomplete(self, interaction: discord.Interaction, current: str) -> list[
+        Choice[str | int | float]]:
         return [app_commands.Choice(name=tz, value=tz) for tz in COMMON_TIMEZONES if current.lower() in tz.lower()][:25]
 
-    async def interval_autocomplete(self, interaction: discord.Interaction, current: str) -> List[
-        app_commands.Choice[int]]:
+    async def interval_autocomplete(self, interaction: discord.Interaction, current: str) -> list[
+        Choice[str | int | float]]:
         return [app_commands.Choice(name=name, value=sec) for name, sec in SLOWMODE_INTERVALS.items() if
                 current.lower() in name.lower()][:25]
 
@@ -236,7 +237,7 @@ class ScheduledSlowmode(commands.Cog):
     @app_commands.describe(channel="The channel to configure slowmode for",
                            interval="The slowmode delay interval (or Disable)")
     @app_commands.autocomplete(interval=interval_autocomplete_with_disable)
-    @preconditions.has_permissions(manage_slowmode=True)
+    @preconditions.has_permissions(manage_channels=True)
     async def configure_slowmode(self, interaction: discord.Interaction, channel: discord.TextChannel, interval: int):
         try:
             await channel.edit(slowmode_delay=interval)
@@ -261,7 +262,7 @@ class ScheduledSlowmode(commands.Cog):
                            timezone="Your timezone region", start_time="Start time (e.g., 14:00 or 02:00 PM)",
                            end_time="End time (e.g., 18:00 or 06:00 PM)")
     @app_commands.autocomplete(timezone=timezone_autocomplete, interval=interval_autocomplete)
-    @preconditions.has_permissions(manage_slowmode=True)
+    @preconditions.has_permissions(manage_channels=True)
     async def schedule_start(self, interaction: discord.Interaction, channel: discord.TextChannel, interval: int,
                              timezone: str, start_time: str, end_time: str):
         if not await self.check_vote_access(interaction.user.id):
@@ -319,7 +320,7 @@ class ScheduledSlowmode(commands.Cog):
 
     @schedule_group.command(name="delete", description="Delete all slowmode schedules for a channel")
     @app_commands.describe(channel="The channel to clear schedules for")
-    @preconditions.has_permissions(manage_slowmode=True)
+    @preconditions.has_permissions(manage_channels=True)
     async def schedule_delete(self, interaction: discord.Interaction, channel: discord.TextChannel):
         if channel.id not in self._schedule_cache or not self._schedule_cache[channel.id]:
             return await interaction.response.send_message(embed=discord.Embed(title="No Schedules",

--- a/cogs/statuscycler.py
+++ b/cogs/statuscycler.py
@@ -26,6 +26,7 @@ class StatusCog(commands.Cog):
             "✨ Watching downfall of GiveawayBot",
             f"✨ Watching {user_installs} User-installs",
             "✨ A charity case?",
+            "✨ i got the best moderation bro",
             "✨ Am the open source underdog",
             "✨ boy are you a dopamine? cuz i wanna make you dopaMINE!",
             "✨ Powered by Beacon Framework!",
@@ -33,6 +34,7 @@ class StatusCog(commands.Cog):
             "✨ Watching downfall of GiveawayBoat",
             "✨ girl are you dopamine? cuz damn youre dopaFINE!",
             "✨ It's so hard being the best!",
+            "✨ moderator? i barely know her",
             "✨ Giving Sapphire a hug (aww!)"
         ]
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import asyncio
 import discord
 from config import TOKEN, LOGGING_DEBUG_MODE
 from logging.handlers import RotatingFileHandler
-from beacon import Bot
+from beacon import BeaconAutoShardedBot
 import traceback
 
 if not TOKEN:
@@ -40,13 +40,14 @@ intents.members = True
 intents.reactions = True
 
 
-bot = Bot(
+bot = BeaconAutoShardedBot(
     command_prefix="!!",
     cogs_path="cogs",
     version_file="VERSION.py",
     accent_colour=discord.Colour(0x944ae8),
-    minimal_cacheing=True,
-    intents=intents
+    minimal_caceing=True,
+    intents=intents,
+    bot_logger=logger
 )
 
 @bot.tree.context_menu(name="Get User ID")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiosqlite~=0.22.1
 discord.py~=2.7.1
-discord-beacon~=3.2.6
+discord-beacon~=4.1.15
 emoji~=2.15.0
 psutil~=7.2.2
 RapidFuzz~=3.14.5
@@ -10,6 +10,6 @@ inflect~=7.5.0
 natsort~=8.4.0
 pyvips~=3.1.1
 aiohttp~=3.14.1
-pillow~=12.2.0
+pillow~=12.3.0
 pytz~=2026.2
 python-dotenv~=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiosqlite~=0.22.1
 discord.py~=2.7.1
-discord-beacon~=4.1.15
+discord-beacon~=4.1.16
 emoji~=2.15.0
 psutil~=7.2.2
 RapidFuzz~=3.14.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiosqlite~=0.22.1
 discord.py~=2.7.1
+discord-beacon~=3.2.6
 emoji~=2.15.0
 psutil~=7.2.2
 RapidFuzz~=3.14.5


### PR DESCRIPTION
# v4.1.0 - An update so generic that we can't name it

This is one of the most generic updates for Dopamine ever, and perhaps in a good way. Almost all key features have been changed to the same degree, nothing stands out above others. New features, improvements, bug fixes, and more. Here's all the important and key changes made.

---

## New Features & Improvements

### AFK

* New "Notify Upon Return" AFK feature that allows others to receive a DM when you're back from being AFK.
* Completely revamped pagination of missed ping messages list.
*  "View Missed Pings" button is now removed after DM is successfully sent or after 120 seconds of coming back from AFK, and missed ping messages are cleared from memory after the same two conditions instead of sitting in memory forever if the user doesn't view them.
* Other improvements to user experience.

### Moderation
*  Rename /case all to /case users to give it a more accurate name.
* Add a new `/case all` command that shows cases instead of users.

### Notes
*  Change note undo button style to secondary, and timeout to 10 seconds instead of 30 to match moderation undo button.

### Autopublish
*  Implement a strict queue to prevent API rate-limits by exceeding the 10 posts per hour limit for publishing.

---

## Bug Fixes & Misc. Changes
* Fix /pardon errors when trying to use it on a user that is no longer in the server.
* Fix errors in Autopublish caused by a stupid implementation of channel picker for disable command.
* Fix interaction expiring in View Cases button before the bot can fetch all the data and edit the message, thanks to @voidxb on Discord for reporting the bug.
* Add more deferring to appropriate moderation commands to prevent interaction expiration.
* Fix `/di` response not being ephemeral.
* Fix error in notes: Error updating note: 'NoteEditModal' object has no attribute 'old_content'
* Rename middle button to Go To Page instead of being a redundant page number display to match the rest of the UI (although using the go to page button's label for page number display instead of an entire new textdisplay for it isn't a bad idea. I might come back to this and change everything to use that pattern).
* Fix haiku detection disable command, thanks to @geniusgd on Discord for reporting the bug. 
* Made haiku detection disabled by default again based on community feedback.
* Fix error in Moderation delete confirmation view caused when target user isn't in the server.
* Fix back button in Giveaway feature returning two steps back in the use page for my templates instead of one step back.
* Fix error after sending confirmation message in Autoresponse.
* Fix errors caused by wrong permission name in slowmode commands.
* Fix swapped data in save_giveaway function.
* Fix wrong type of winner_role_id column.
* Made the code for AFK and Autoreact type-safe, others will be done over time with newer updates.

<sub>For detailed changelogs, you can read the Git commit history by [clicking here](https://github.com/likerofturtles/dopamine/commits/main/).